### PR TITLE
Consents banner now able to overwrite the default text

### DIFF
--- a/dev/cb.dev.js
+++ b/dev/cb.dev.js
@@ -179,6 +179,17 @@ function intaGetTextOverride(key, fallbackText) {
     var override = intaGetRawTextOverride(key);
     return override !== null ? override : fallbackText;
 }
+
+/** Decline / necessary-only label: `necessaryButton`, aliases `declineButton`, `declineAllButton`. */
+function intaGetNecessaryButtonText(fallbackText) {
+    var o = intaGetRawTextOverride("necessaryButton");
+    if (o !== null) return o;
+    o = intaGetRawTextOverride("declineButton");
+    if (o !== null) return o;
+    o = intaGetRawTextOverride("declineAllButton");
+    if (o !== null) return o;
+    return fallbackText;
+}
 /* const poweredBy = `<a class="inta-poweredBy" href='https://www.intastellarsolutions.com?utm_source=${encodeURI(window.location.href)}&utm_content=powered_by&utm_medium=referral&utm_campaign=Consents+Block&utm_term=gdpr_banner_logo' target='_blank' rel='noopener' style="align-items: center; text-decoration: none;font-size: 11.5px; color: #000 !important; display: flex; justify-content: center;">powered by <img width="109px" height="20px" style="width: 109px !important; height: 20px !important;margin-left: 10px;" src="https://www.intastellarsolutions.com/assets/intastellar_solutions.svg" alt="Intastellar Solutions, International"></a>`; */
 const banner = document.createElement("inta-consents-settings-btn");
 const bannerContent = document.createElement("button");
@@ -4293,7 +4304,7 @@ if (intastellarCookieLanguage != null && intastellarCookieLanguage === "en" || i
     settingsSaveLang.necessaryCookiesText = "Afvis";
     settingsSaveLang.saveSettingsText = "Gem";
 }
-settingsSaveLang.necessaryCookiesText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
+settingsSaveLang.necessaryCookiesText = intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText);
 
 function updateSaveButtonText() {
     const FunctionalCheckbox = document.querySelector("#functional");
@@ -4303,18 +4314,19 @@ function updateSaveButtonText() {
 
     const vendorChecks = document.querySelectorAll('.intCookieSetting__checkbox');
     const vendorLegitChecks = document.querySelectorAll('.intCookieSetting__checkbox-legit');
-    const vendorChecksChecked = Array.from(vendorChecks).every(check => check.checked);
-    const vendorLegitChecksChecked = Array.from(vendorLegitChecks).every(check => check.checked);
+    const vendorChecksChecked = vendorChecks.length > 0 && Array.from(vendorChecks).every(function (check) { return check.checked; });
+    const vendorLegitChecksChecked = vendorLegitChecks.length > 0 && Array.from(vendorLegitChecks).every(function (check) { return check.checked; });
 
     if (!saveBtn) return;
     if (
         (FunctionalCheckbox && FunctionalCheckbox.checked) ||
         (StaticsCheckBox && StaticsCheckBox.checked) ||
-        (MarketingCheckBox && MarketingCheckBox.checked)
+        (MarketingCheckBox && MarketingCheckBox.checked) ||
+        vendorChecksChecked || vendorLegitChecksChecked
     ) {
         saveBtn.innerText = intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText);
     } else {
-        saveBtn.innerText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
+        saveBtn.innerText = intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText);
     }
 
     console.log((FunctionalCheckbox && FunctionalCheckbox.checked) ||
@@ -5858,7 +5870,7 @@ function generatePolicyUrl(policy_link_text) {
 }
 function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSettingsText) {
     var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
-    var necessaryOnlyText = intaGetTextOverride("necessaryButton", necessaryCookiesText);
+    var necessaryOnlyText = intaGetNecessaryButtonText(necessaryCookiesText);
     var settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
     return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button>'
         + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery" onclick="javascript:IntaSaveNeccessary();">' + necessaryOnlyText + '</button>'
@@ -5866,8 +5878,8 @@ function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSetti
 }
 
 function generateCookieSettingsButton(settingsText, allCookiesText) {
-    const saveSettingsText = settingsText;
-    const acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    var saveSettingsText = intaGetTextOverride("saveSettingsButton", settingsText);
+    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
     return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save" onclick="javascript:IntaSaveSettings();">' + saveSettingsText + '</button>'
         + '<button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button></section>'
         ;

--- a/dev/cb.dev.js
+++ b/dev/cb.dev.js
@@ -158,6 +158,27 @@ function darkLightCheck(color) {
 
 let message = "";
 let cookieBtn = "";
+function intaGetTextOverrides() {
+    var settings = window.INTA && window.INTA.settings;
+    if (settings && typeof settings.textOverrides === "object" && settings.textOverrides !== null) {
+        return settings.textOverrides;
+    }
+    return {};
+}
+
+function intaGetRawTextOverride(key) {
+    var overrides = intaGetTextOverrides();
+    var value = overrides[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+        return value;
+    }
+    return null;
+}
+
+function intaGetTextOverride(key, fallbackText) {
+    var override = intaGetRawTextOverride(key);
+    return override !== null ? override : fallbackText;
+}
 /* const poweredBy = `<a class="inta-poweredBy" href='https://www.intastellarsolutions.com?utm_source=${encodeURI(window.location.href)}&utm_content=powered_by&utm_medium=referral&utm_campaign=Consents+Block&utm_term=gdpr_banner_logo' target='_blank' rel='noopener' style="align-items: center; text-decoration: none;font-size: 11.5px; color: #000 !important; display: flex; justify-content: center;">powered by <img width="109px" height="20px" style="width: 109px !important; height: 20px !important;margin-left: 10px;" src="https://www.intastellarsolutions.com/assets/intastellar_solutions.svg" alt="Intastellar Solutions, International"></a>`; */
 const banner = document.createElement("inta-consents-settings-btn");
 const bannerContent = document.createElement("button");
@@ -1704,6 +1725,11 @@ if (intastellarCookieLanguage != null) {
     } else if (intastellarCookieLanguage === "en" || intastellarCookieLanguage === "en-GB" || intastellarCookieLanguage === "en-US") {
         settingsMessage = settingsMessagesLanguages.english;
         intastellarShowHideDetailsText = "Show details";
+        if (window.INTA.settings.textOverrides) {
+            settingsMessage = window.INTA.settings.textOverrides.bannerMessageHtml;
+            intastellarShowHideDetailsText = window.INTA.settings.textOverrides.showDetailsText;
+            messages.english = window.INTA.settings.textOverrides.bannerMessageHtml;
+        }
         message =
             messageWrapStart
             + messages.english
@@ -3849,6 +3875,7 @@ if (ccpa) {
 } */
 
 cookieSettingsContent.setAttribute("class", "intastellarCookie-settings__content");
+message = intaGetTextOverride("bannerMessageHtml", message);
 
 let intCookieIconSmallClass = cookieLogo == intCookieIcon ? " intastellarIcon" : "";
 let CompanyLogoName = cookieLogo == intCookieIcon ? "Cookie Icon" : `${document.domain} logo`;
@@ -4266,6 +4293,7 @@ if (intastellarCookieLanguage != null && intastellarCookieLanguage === "en" || i
     settingsSaveLang.necessaryCookiesText = "Afvis";
     settingsSaveLang.saveSettingsText = "Gem";
 }
+settingsSaveLang.necessaryCookiesText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
 
 function updateSaveButtonText() {
     const FunctionalCheckbox = document.querySelector("#functional");
@@ -5829,14 +5857,19 @@ function generatePolicyUrl(policy_link_text) {
     return url;
 }
 function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSettingsText) {
-    return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + allCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery" onclick="javascript:IntaSaveNeccessary();">' + necessaryCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings" onclick="javascript:IntaSaveSettings();">' + cookieSettingsText + '</button>';
+    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    var necessaryOnlyText = intaGetTextOverride("necessaryButton", necessaryCookiesText);
+    var settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
+    return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery" onclick="javascript:IntaSaveNeccessary();">' + necessaryOnlyText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings" onclick="javascript:IntaSaveSettings();">' + settingsText + '</button>';
 }
 
 function generateCookieSettingsButton(settingsText, allCookiesText) {
-    return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save" onclick="javascript:IntaSaveSettings();">' + settingsText + '</button>'
-        + '<button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + allCookiesText + '</button></section>'
+    var saveSettingsText = intaGetTextOverride("saveSettingsButton", settingsText);
+    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save" onclick="javascript:IntaSaveSettings();">' + saveSettingsText + '</button>'
+        + '<button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button></section>'
         ;
 }
 /* - - - Helper function for ccpa URL generator */

--- a/dev/cb.dev.js
+++ b/dev/cb.dev.js
@@ -4312,9 +4312,9 @@ function updateSaveButtonText() {
         (StaticsCheckBox && StaticsCheckBox.checked) ||
         (MarketingCheckBox && MarketingCheckBox.checked)
     ) {
-        saveBtn.innerText = settingsSaveLang.saveSettingsText;
+        saveBtn.innerText = intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText);
     } else {
-        saveBtn.innerText = settingsSaveLang.necessaryCookiesText;
+        saveBtn.innerText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
     }
 
     console.log((FunctionalCheckbox && FunctionalCheckbox.checked) ||
@@ -5866,8 +5866,8 @@ function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSetti
 }
 
 function generateCookieSettingsButton(settingsText, allCookiesText) {
-    var saveSettingsText = intaGetTextOverride("saveSettingsButton", settingsText);
-    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    const saveSettingsText = settingsText;
+    const acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
     return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save" onclick="javascript:IntaSaveSettings();">' + saveSettingsText + '</button>'
         + '<button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button></section>'
         ;

--- a/dev/cb.dev.js
+++ b/dev/cb.dev.js
@@ -159,7 +159,7 @@ function darkLightCheck(color) {
 let message = "";
 let cookieBtn = "";
 function intaGetTextOverrides() {
-    var settings = window.INTA && window.INTA.settings;
+    let settings = window.INTA && window.INTA.settings;
     if (settings && typeof settings.textOverrides === "object" && settings.textOverrides !== null) {
         return settings.textOverrides;
     }
@@ -167,8 +167,8 @@ function intaGetTextOverrides() {
 }
 
 function intaGetRawTextOverride(key) {
-    var overrides = intaGetTextOverrides();
-    var value = overrides[key];
+    let overrides = intaGetTextOverrides();
+    let value = overrides[key];
     if (typeof value === "string" && value.trim().length > 0) {
         return value;
     }
@@ -176,19 +176,209 @@ function intaGetRawTextOverride(key) {
 }
 
 function intaGetTextOverride(key, fallbackText) {
-    var override = intaGetRawTextOverride(key);
+    let override = intaGetRawTextOverride(key);
     return override !== null ? override : fallbackText;
 }
 
 /** Decline / necessary-only label: `necessaryButton`, aliases `declineButton`, `declineAllButton`. */
 function intaGetNecessaryButtonText(fallbackText) {
-    var o = intaGetRawTextOverride("necessaryButton");
+    let o = intaGetRawTextOverride("necessaryButton");
     if (o !== null) return o;
     o = intaGetRawTextOverride("declineButton");
     if (o !== null) return o;
     o = intaGetRawTextOverride("declineAllButton");
     if (o !== null) return o;
     return fallbackText;
+}
+
+/** Merge server / experiment text override keys into `window.INTA.settings.textOverrides`. */
+function intaMergeTextOverridesIntoSettings(incomingTO) {
+    if (!incomingTO || typeof incomingTO !== "object" || incomingTO === null || Array.isArray(incomingTO)) {
+        return;
+    }
+    if (!window.INTA || !window.INTA.settings) {
+        return;
+    }
+    let existingTO = window.INTA.settings.textOverrides;
+    let mergedTO = {};
+    if (existingTO && typeof existingTO === "object" && existingTO !== null && !Array.isArray(existingTO)) {
+        for (let bk in existingTO) {
+            if (existingTO.hasOwnProperty(bk)) {
+                mergedTO[bk] = existingTO[bk];
+            }
+        }
+    }
+    for (let ik in incomingTO) {
+        if (incomingTO.hasOwnProperty(ik)) {
+            mergedTO[ik] = incomingTO[ik];
+        }
+    }
+    window.INTA.settings.textOverrides = mergedTO;
+}
+
+function intaCbResolveExperimentVariantId(exp) {
+    if (!exp || !exp.id || !exp.variants || !Object.keys(exp.variants).length) {
+        return null;
+    }
+    if (window.INTA && window.INTA.experimentVariant && exp.variants[window.INTA.experimentVariant]) {
+        return window.INTA.experimentVariant;
+    }
+    let expKey = "inta_exp_" + exp.id;
+    let stored = null;
+    try {
+        stored = sessionStorage.getItem(expKey);
+    } catch (e) { }
+    let variantId = stored;
+    if (!variantId) {
+        let variants = exp.variants;
+        let total = 0;
+        let ids = [];
+        for (let k in variants) {
+            if (variants.hasOwnProperty(k)) {
+                let w = Math.max(0, parseInt(variants[k].weight, 10) || 50);
+                total += w;
+                ids.push({ id: k, weight: w });
+            }
+        }
+        if (total <= 0) {
+            return null;
+        }
+        let r = (function simpleHash() {
+            let s = exp.id + (navigator.userAgent || "") + (document.referrer || "") + (new Date().getDate());
+            let h = 0;
+            for (let i = 0; i < s.length; i++) {
+                h = ((h << 5) - h) + s.charCodeAt(i) | 0;
+            }
+            return Math.abs(h) % 10000 / 10000;
+        })();
+        let bucket = r * total;
+        for (let j = 0; j < ids.length; j++) {
+            bucket -= ids[j].weight;
+            if (bucket <= 0) {
+                variantId = ids[j].id;
+                break;
+            }
+        }
+        variantId = variantId || (ids[0] && ids[0].id);
+        try {
+            sessionStorage.setItem(expKey, variantId);
+        } catch (e2) { }
+    }
+    return variantId;
+}
+
+/** Preset slug from gdpr `__intaTextOverridePresetId`, `INTA.settings`, or active experiment variant. */
+function intaCbResolveTextOverridePresetSlug() {
+    if (typeof window.__intaTextOverridePresetId === "string" && window.__intaTextOverridePresetId.trim()) {
+        return window.__intaTextOverridePresetId.trim();
+    }
+    let s = window.INTA && window.INTA.settings;
+    if (s) {
+        if (s.textOverridePresetId != null && String(s.textOverridePresetId).trim() !== "") {
+            return String(s.textOverridePresetId).trim();
+        }
+        if (s.textOverridesPresetId != null && String(s.textOverridesPresetId).trim() !== "") {
+            return String(s.textOverridesPresetId).trim();
+        }
+    }
+    let exp = window.INTA && window.INTA.experiment;
+    let variantId = intaCbResolveExperimentVariantId(exp);
+    if (!exp || !variantId || !exp.variants || !exp.variants[variantId]) {
+        return null;
+    }
+    let v = exp.variants[variantId];
+    let overrides = (v && v.settings) || (exp.overrides && exp.overrides[variantId]) || {};
+    if (overrides.textOverridePresetId != null && String(overrides.textOverridePresetId).trim() !== "") {
+        return String(overrides.textOverridePresetId).trim();
+    }
+    if (overrides.textOverridesPresetId != null && String(overrides.textOverridesPresetId).trim() !== "") {
+        return String(overrides.textOverridesPresetId).trim();
+    }
+    return null;
+}
+
+const intaCbTextOverridePresetApiUrl = "https://apis.intastellarsolutions.com/cmp/presets";
+
+/**
+ * Normalizes preset API JSON: either a flat textOverrides map or `{ textOverrides: { ... } }`.
+ * Rejects non-objects; coerces a JSON string body once.
+ */
+function intaCbNormalizePresetApiBody(data) {
+    if (data == null) {
+        return null;
+    }
+    if (typeof data === "string") {
+        try {
+            data = JSON.parse(data);
+        } catch (e) {
+            return null;
+        }
+    }
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+        return null;
+    }
+    const nested = data.textOverrides;
+    if (nested && typeof nested === "object" && nested !== null && !Array.isArray(nested) && Object.keys(nested).length > 0) {
+        return nested;
+    }
+    const flat = {};
+    for (const key in data) {
+        if (Object.prototype.hasOwnProperty.call(data, key) && key !== "textOverrides") {
+            flat[key] = data[key];
+        }
+    }
+    return Object.keys(flat).length ? flat : null;
+}
+
+/** After preset merge, refresh button labels that were built before fetch (cookieBtn + more-settings strip). */
+function intaCbSyncTextOverrideLabelsInScope(scope) {
+    if (!scope || typeof scope.querySelectorAll !== "function") {
+        return;
+    }
+    scope.querySelectorAll(".intastellarCookieSettings--acceptAll").forEach(function (el) {
+        const cur = el.textContent || "";
+        el.textContent = intaGetTextOverride("acceptAllButton", cur);
+    });
+    scope.querySelectorAll(".intastellarCookieBanner__accpetNecssery").forEach(function (el) {
+        const cur = el.textContent || "";
+        el.textContent = intaGetNecessaryButtonText(cur);
+    });
+    scope.querySelectorAll(".intastellarCookieBanner__settings").forEach(function (el) {
+        const cur = el.textContent || "";
+        if (el.classList && el.classList.contains("--save")) {
+            el.textContent = intaGetTextOverride("saveSettingsButton", cur);
+        } else {
+            el.textContent = intaGetTextOverride("settingsButton", cur);
+        }
+    });
+}
+
+/** Fetches published preset JSON when a text-override preset id exists; merges into `textOverrides`. */
+function intaCbFetchTextOverridePresetFromApiIfNeeded() {
+    let slug = intaCbResolveTextOverridePresetSlug();
+    if (!slug || typeof fetch !== "function") {
+        return Promise.resolve();
+    }
+    let url = intaCbTextOverridePresetApiUrl + "?slug=" + encodeURIComponent(slug);
+    return fetch(url, { credentials: "omit", cache: "no-store" })
+        .then(function (res) {
+            if (!res.ok) {
+                throw new Error("HTTP " + res.status);
+            }
+            return res.json();
+        })
+        .then(function (data) {
+            const payload = intaCbNormalizePresetApiBody(data);
+            if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+                intaMergeTextOverridesIntoSettings(payload);
+            }
+            try {
+                window.dispatchEvent(new CustomEvent("inta:text-override-preset-loaded", { detail: { presetId: slug, source: "presets.php" } }));
+            } catch (evErr) { }
+        })
+        .catch(function (err) {
+            console.warn("[Intastellar] CMP preset fetch failed:", slug, err && err.message ? err.message : err);
+        });
 }
 /* const poweredBy = `<a class="inta-poweredBy" href='https://www.intastellarsolutions.com?utm_source=${encodeURI(window.location.href)}&utm_content=powered_by&utm_medium=referral&utm_campaign=Consents+Block&utm_term=gdpr_banner_logo' target='_blank' rel='noopener' style="align-items: center; text-decoration: none;font-size: 11.5px; color: #000 !important; display: flex; justify-content: center;">powered by <img width="109px" height="20px" style="width: 109px !important; height: 20px !important;margin-left: 10px;" src="https://www.intastellarsolutions.com/assets/intastellar_solutions.svg" alt="Intastellar Solutions, International"></a>`; */
 const banner = document.createElement("inta-consents-settings-btn");
@@ -219,7 +409,7 @@ function generateTcString(consentObj) {
     if (!window.IABTCF || !window.IABTCF.TCModel || !window.IABTCF.TCString) {
         throw new Error('IAB TCF encoder bundle not loaded.');
     }
-    var model = new window.IABTCF.TCModel();
+    let model = new window.IABTCF.TCModel();
     model.cmpId = 1;
     // Set purposes and vendors as boolean arrays (first 24)
     model.purposeConsents = (consentObj.purposes || []).slice(0, 24);
@@ -250,9 +440,9 @@ const tcString = generateTcString(exampleConsent);
 
 // Time-to-decision: compute and attach to consent object for analytics/backend
 function recordTimeToDecision(decisionType) {
-    var shownAt = window._intaBannerShownAt;
+    let shownAt = window._intaBannerShownAt;
     if (typeof shownAt !== 'number') return;
-    var elapsed = Math.round(Date.now() - shownAt);
+    let elapsed = Math.round(Date.now() - shownAt);
     window._intaBannerShownAt = undefined;
     if (typeof intaConsentsObjectVariable !== 'undefined') {
         intaConsentsObjectVariable.time_to_decision = elapsed;
@@ -267,7 +457,7 @@ function recordTimeToDecision(decisionType) {
 // Pass true/ 'useractioncomplete' when user clicked; false/'tcloaded' when consent loaded/restored without user interaction
 function dispatchTCFConsentChangedIfAvailable(wasUserInteraction) {
     if (typeof window.__tcfapiDispatchConsentChanged === 'function') {
-        var eventStatus = (wasUserInteraction === false || wasUserInteraction === 'tcloaded') ? 'tcloaded' : 'useractioncomplete';
+        let eventStatus = (wasUserInteraction === false || wasUserInteraction === 'tcloaded') ? 'tcloaded' : 'useractioncomplete';
         window.__tcfapiDispatchConsentChanged(eventStatus);
     }
 }
@@ -515,7 +705,7 @@ function closePOPIAModal() {
  * Prevents creating fake Shopify globals on non-Shopify sites — those caused setTrackingConsent to be missing → TypeError.
  */
 function intaIsShopifyStorefrontContext() {
-    var s = window.Shopify;
+    let s = window.Shopify;
     if (!s || typeof s !== "object") return false;
     return typeof s.loadFeatures === "function" || typeof s.shop === "string" || typeof s.theme === "object";
 }
@@ -537,7 +727,7 @@ function intaHideShopifyNativeConsentBanner() {
         };
 
         if (!document.getElementById('inta-shopify-native-banner-hide')) {
-            var st = document.createElement('style');
+            let st = document.createElement('style');
             st.id = 'inta-shopify-native-banner-hide';
             st.textContent =
                 '#shopify-pc__banner, #shopify-pc__prefs, .shopify-pc__banner, .shopify-pc__prefs, ' +
@@ -546,14 +736,14 @@ function intaHideShopifyNativeConsentBanner() {
             (document.head || document.documentElement).appendChild(st);
         }
 
-        var shopifyPcSelectors = [
+        let shopifyPcSelectors = [
             '#shopify-pc__banner',
             '#shopify-pc__prefs',
             '.shopify-pc__banner',
             '.shopify-pc__prefs',
             '[data-shopify-pc-banner]',
         ];
-        for (var si = 0; si < shopifyPcSelectors.length; si++) {
+        for (let si = 0; si < shopifyPcSelectors.length; si++) {
             try {
                 document.querySelectorAll(shopifyPcSelectors[si]).forEach(function (el) {
                     el.style.setProperty('display', 'none', 'important');
@@ -565,7 +755,7 @@ function intaHideShopifyNativeConsentBanner() {
     } catch (e) { /* ignore */ }
 }
 
-var intaShopifyHideBannerRaf = null;
+let intaShopifyHideBannerRaf = null;
 function intaScheduleHideShopifyNativeBanner() {
     if (intaShopifyHideBannerRaf != null) {
         return;
@@ -582,7 +772,7 @@ function intaScheduleHideShopifyNativeBanner() {
     if (typeof MutationObserver === 'undefined') {
         return;
     }
-    var mo = new MutationObserver(function () {
+    let mo = new MutationObserver(function () {
         intaScheduleHideShopifyNativeBanner();
     });
     function attach() {
@@ -777,24 +967,24 @@ if (typeof window.denyAllCookies === 'function') {
 // --- TCF 2.2 API stub with event listener registry and dynamic dispatch ---
 (function () {
     // TCF event listener registry
-    var tcfListeners = {};
-    var tcfListenerId = 1;
-    var lastUserActionAt = 0;  // timestamp when useractioncomplete was last dispatched
-    var USER_ACTION_WINDOW_MS = 30000;  // getTCData returns useractioncomplete for this long after dispatch
+    let tcfListeners = {};
+    let tcfListenerId = 1;
+    let lastUserActionAt = 0;  // timestamp when useractioncomplete was last dispatched
+    const USER_ACTION_WINDOW_MS = 30000;  // getTCData returns useractioncomplete for this long after dispatch
 
     function getCurrentConsentForTCF() {
         try {
-            var consentCookie = typeof getCookie === 'function' ? getCookie(int_hideCookieBannerName) : null;
+            let consentCookie = typeof getCookie === 'function' ? getCookie(int_hideCookieBannerName) : null;
             if (consentCookie && consentCookie.indexOf('__inta') > -1) {
-                var consentsObj = JSON.parse(decodeIntaConsentsObject(consentCookie.split('.')[2]));
-                var purposes = [
+                let consentsObj = JSON.parse(decodeIntaConsentsObject(consentCookie.split('.')[2]));
+                let purposes = [
                     true, // 1: Always necessary
                     !!consentsObj.consents?.functionalCookies, // 2: functional
                     !!consentsObj.consents?.staticsticCookies, // 3: statistic
                     !!consentsObj.consents?.advertisementCookies // 4: marketing
                 ];
                 while (purposes.length < 24) purposes.push(false);
-                var vendors = Array(24).fill(true);
+                let vendors = Array(24).fill(true);
                 return { purposes, vendors };
             }
         } catch (e) { }
@@ -805,8 +995,8 @@ if (typeof window.denyAllCookies === 'function') {
     }
 
     function buildTCData(eventStatus, listenerIdOverride) {
-        var consentObj = getCurrentConsentForTCF();
-        var tcString = generateTcString(consentObj);
+        let consentObj = getCurrentConsentForTCF();
+        let tcString = generateTcString(consentObj);
         return {
             tcString: tcString,
             eventStatus: eventStatus || 'tcloaded',
@@ -817,12 +1007,12 @@ if (typeof window.denyAllCookies === 'function') {
     }
 
     function dispatchTCFEvent(eventStatus) {
-        var status = (eventStatus === 'tcloaded' || eventStatus === 'cmpuishown') ? eventStatus : 'useractioncomplete';
+        let status = (eventStatus === 'tcloaded' || eventStatus === 'cmpuishown') ? eventStatus : 'useractioncomplete';
         if (status === 'useractioncomplete') lastUserActionAt = Date.now();
         Object.keys(tcfListeners).forEach(function (id) {
-            var cb = tcfListeners[id];
+            let cb = tcfListeners[id];
             if (typeof cb === 'function') {
-                var tcData = buildTCData(status, parseInt(id));
+                let tcData = buildTCData(status, parseInt(id));
                 cb(tcData, true);
             }
         });
@@ -830,15 +1020,15 @@ if (typeof window.denyAllCookies === 'function') {
 
     window.__tcfapi = function (command, version, callback, parameter) {
         if (command === 'getTCData') {
-            var getStatus = (lastUserActionAt && (Date.now() - lastUserActionAt) < USER_ACTION_WINDOW_MS)
+            let getStatus = (lastUserActionAt && (Date.now() - lastUserActionAt) < USER_ACTION_WINDOW_MS)
                 ? 'useractioncomplete' : 'tcloaded';
-            var tcData = buildTCData(getStatus);
+            let tcData = buildTCData(getStatus);
             callback(tcData, true);
         } else if (command === 'addEventListener') {
-            var id = tcfListenerId++;
+            let id = tcfListenerId++;
             tcfListeners[id] = callback;
             // Initial eventStatus is 'tcloaded' per spec
-            var tcData = buildTCData('tcloaded', id);
+            let tcData = buildTCData('tcloaded', id);
             callback(tcData, true);
         } else if (command === 'removeEventListener') {
             // parameter is the listenerId
@@ -989,7 +1179,7 @@ function applyTcStringToVendorCheckboxes(tcString, vendors) {
         return;
     }
     try {
-        var decoded = window.IABTCF && window.IABTCF.TCString && typeof window.IABTCF.TCString.decode === 'function'
+        let decoded = window.IABTCF && window.IABTCF.TCString && typeof window.IABTCF.TCString.decode === 'function'
             ? window.IABTCF.TCString.decode(tcString) : null;
         if (typeof intastellarDevMode !== 'undefined' && intastellarDevMode) {
             console.log('[applyTcStringToVendorCheckboxes] decoded:', decoded);
@@ -1001,10 +1191,10 @@ function applyTcStringToVendorCheckboxes(tcString, vendors) {
             return;
         }
         vendors.forEach(function (vendor, i) {
-            var idx = parseInt(vendor.id, 10) - 1;
+            let idx = parseInt(vendor.id, 10) - 1;
             if (idx < 0 || idx >= decoded.vendors.length) return;
-            var cb = document.getElementById('vendor' + vendor.id);
-            var legitCb = document.getElementById('vendor' + vendor.id + '-legit');
+            let cb = document.getElementById('vendor' + vendor.id);
+            let legitCb = document.getElementById('vendor' + vendor.id + '-legit');
             if (cb) cb.checked = !!decoded.vendors[idx];
             if (legitCb && decoded.vendorLegitimateInterests && decoded.vendorLegitimateInterests[idx] !== undefined) {
                 legitCb.checked = !!decoded.vendorLegitimateInterests[idx];
@@ -1017,10 +1207,10 @@ function applyTcStringToVendorCheckboxes(tcString, vendors) {
 
 function getTcStringFromCookie() {
     try {
-        var c = typeof getCookie === 'function' ? getCookie(int_hideCookieBannerName) : null;
+        let c = typeof getCookie === 'function' ? getCookie(int_hideCookieBannerName) : null;
         if (c && c.indexOf && c.indexOf('__inta') > -1) {
-            var parts = c.split('.');
-            var decoded = parts[2] ? JSON.parse(decodeIntaConsentsObject(parts[2]) || '{}') : {};
+            let parts = c.split('.');
+            let decoded = parts[2] ? JSON.parse(decodeIntaConsentsObject(parts[2]) || '{}') : {};
             return decoded.tcString || null;
         }
     } catch (e) {}
@@ -1053,7 +1243,7 @@ function getTcStringFromCookie() {
             `;
             vendorListContainer.appendChild(vendorDiv);
     });
-    var __intaTcStrForVendors = getTcStringFromCookie();
+    let __intaTcStrForVendors = getTcStringFromCookie();
     if (__intaTcStrForVendors) {
         applyTcStringToVendorCheckboxes(__intaTcStrForVendors, vendors);
     }
@@ -1063,32 +1253,32 @@ function getTcStringFromCookie() {
         saveBtn._vendorSaveListenerAttached = true;
         saveBtn.addEventListener('click', function handleVendorSave() {
             // Build consent and disclosed arrays by GVL vendor ID (required for TCF 2.3)
-            var maxVendorId = vendors.length ? Math.max.apply(null, vendors.map(function (v) { return parseInt(v.id, 10) || 0; })) : 0;
-            var vendorConsentsById = [];
-            var disclosedVendorsById = [];
-            for (var i = 0; i < maxVendorId; i++) {
+            let maxVendorId = vendors.length ? Math.max.apply(null, vendors.map(function (v) { return parseInt(v.id, 10) || 0; })) : 0;
+            let vendorConsentsById = [];
+            let disclosedVendorsById = [];
+            for (let i = 0; i < maxVendorId; i++) {
                 vendorConsentsById[i] = false;
                 disclosedVendorsById[i] = false;
             }
             vendors.forEach(function (vendor) {
-                var id = parseInt(vendor.id, 10);
+                let id = parseInt(vendor.id, 10);
                 if (id > 0) {
                     disclosedVendorsById[id - 1] = true;
-                    var cb = document.getElementById('vendor' + vendor.id);
+                    let cb = document.getElementById('vendor' + vendor.id);
                     vendorConsentsById[id - 1] = !!(cb && cb.checked);
                 }
             });
-            var vendorLegitInterests = [];
+            let vendorLegitInterests = [];
             vendors.forEach(function (vendor) {
-                var id = parseInt(vendor.id, 10);
+                let id = parseInt(vendor.id, 10);
                 if (id > 0) {
-                    var legitCb = document.getElementById('vendor' + vendor.id + '-legit');
+                    let legitCb = document.getElementById('vendor' + vendor.id + '-legit');
                     while (vendorLegitInterests.length < id) vendorLegitInterests.push(false);
                     vendorLegitInterests[id - 1] = !!(legitCb && legitCb.checked);
                 }
             });
-            var purposes = Array(24).fill(true);
-            var userConsent = {
+            let purposes = Array(24).fill(true);
+            let userConsent = {
                 purposes: purposes,
                 vendors: vendorConsentsById,
                 disclosedVendors: disclosedVendorsById,
@@ -1753,7 +1943,7 @@ if (intastellarCookieLanguage != null) {
     ${(window.INTA.settings.design == "banner" || window.INTA.settings.design == "bannerV2" && window.INTA.settings.logo && window.INTA.settings.logo != "") ? `
        <img class="intSettingsCompanyLogo" src="${window.INTA.settings.logo}" alt="Intastellar Solutions, International">`
                 : ""}
-        ${generateCookieSettingsButton(window.INTA.settings.textOverrides.necessaryButton, 'Accept')}
+        ${generateCookieSettingsButton(window.INTA.settings?.textOverrides?.necessaryButton || intastellarSupportedLanguages.english.saveSettings, 'Accept')}
         <button class="intLearnMoreBtn" onclick="learnMore(this)" >${intastellarShowHideDetailsText}</button>
         <button class="openVendorList" onclick="openVendorList()">Vendor list</button>
         ${(window.INTA.settings.design == "bannerV2" && window.innerWidth > 768 ? generatePoweredBy() : "")}
@@ -3886,40 +4076,58 @@ if (ccpa) {
 } */
 
 cookieSettingsContent.setAttribute("class", "intastellarCookie-settings__content");
-message = intaGetTextOverride("bannerMessageHtml", message);
+const intaCbBannerMessageBaseHtml = message;
+/** Snapshot before async preset: `moreContentText` was filled earlier and would otherwise stay stale. */
+const intaCbSettingsMessageBaseHtml = settingsMessage;
 
-let intCookieIconSmallClass = cookieLogo == intCookieIcon ? " intastellarIcon" : "";
-let CompanyLogoName = cookieLogo == intCookieIcon ? "Cookie Icon" : `${document.domain} logo`;
+function intaCbApplyMainBannerDomAndInitialize() {
+    message = intaGetTextOverride("bannerMessageHtml", intaCbBannerMessageBaseHtml);
+    moreContentText.innerHTML = intaGetTextOverride("bannerMessageHtml", intaCbSettingsMessageBaseHtml);
 
-moreintHeader.innerHTML = `
+    let intCookieIconSmallClass = cookieLogo == intCookieIcon ? " intastellarIcon" : "";
+    let CompanyLogoName = cookieLogo == intCookieIcon ? "Cookie Icon" : `${document.domain} logo`;
+
+    moreintHeader.innerHTML = `
     ${typeof window?.INTA?.settings.logo != "undefined" ? '<img onerror="this.onerror=null; this.style.display:none;" class="intSettingsCompanyLogo" src="' + window?.INTA?.settings.logo + '" alt="' + CompanyLogoName + '" title="' + CompanyLogoName + '">' : ``}
     ${(window.INTA.settings.design == "overlay" || window.INTA.settings.design == undefined || window.innerWidth < 900) ? `<section class="intSettingsPoweredBy">${poweredBy}</section>` : ""}
     `;
 
-cookieSettingsContent.innerHTML = '<intHeader class="intastellarCookie-settings__intHeader"><img onerror="this.onerror=null; this.style.display:none;" src="' + window?.INTA?.settings.logo + '" alt="' + CompanyLogoName + '" title="' + CompanyLogoName + '" style="width: 100%;float: left; max-width: 50px;max-height: 50px;object-fit:contain;"><h2>Cookie</h2><button class="intastellarCookie-settings__close" style="background: ' + cookieColor + ';" aria-label="Close cookie banner"></button></intHeader>' +
-    message + cookieBtn + "" + (window.INTA.settings.design !== "overlay" || window.INTA.settings.design != undefined) ? poweredBy : (window.innerWidth < 768) ? null : poweredBy + "";
+    cookieSettingsContent.innerHTML = '<intHeader class="intastellarCookie-settings__intHeader"><img onerror="this.onerror=null; this.style.display:none;" src="' + window?.INTA?.settings.logo + '" alt="' + CompanyLogoName + '" title="' + CompanyLogoName + '" style="width: 100%;float: left; max-width: 50px;max-height: 50px;object-fit:contain;"><h2>Cookie</h2><button class="intastellarCookie-settings__close" style="background: ' + cookieColor + ';" aria-label="Close cookie banner"></button></intHeader>' +
+        message + cookieBtn + "" + (window.INTA.settings.design !== "overlay" || window.INTA.settings.design != undefined) ? poweredBy : (window.innerWidth < 768) ? null : poweredBy + "";
 
-cookieSettings.appendChild(cookieSettingsContent);
+    intaCbSyncTextOverrideLabelsInScope(cookieSettingsContent);
+    intaCbSyncTextOverrideLabelsInScope(moreSettingsContent);
 
-if (window?.INTA?.settings.advanced) {
-    //banner.appendChild(cookieSettings);
+    cookieSettings.appendChild(cookieSettingsContent);
+
+    if (window?.INTA?.settings.advanced) {
+        //banner.appendChild(cookieSettings);
+    }
+
+    banner.setAttribute("class", "intastellarCookie-settings");
+
+    bannerContent.innerHTML = '<img class="intCookieIcon-openSettings" style="filter: brightness(' + (darkLightCheck(window.INTA.settings.color) === "light" ? "0" : "100") + ') !important" src="' + intCookieIcon + '" alt="Cookie Icon">' + IntastellarToolTip + ' ' + text;
+
+    banner.appendChild(bannerContent);
+    moreSettings.appendChild(moreSettingsContent);
+    intaconsents.appendChild(banner);
+    intaconsents.appendChild(moreSettings);
+    window._intaCookieConstents = intaconsents;
+    IntastellarCookieConsent.initialize(intaconsents);
+
+    if (document.querySelector(".intastellarCCPAContainer") != null) {
+        document.querySelector(".intastellarCCPAContainer").addEventListener("click", function () {
+            document.querySelector(".intastellarCCPApopup").classList.toggle("--active");
+        });
+    }
 }
 
-banner.setAttribute("class", "intastellarCookie-settings");
-
-bannerContent.innerHTML = '<img class="intCookieIcon-openSettings" style="filter: brightness(' + (darkLightCheck(window.INTA.settings.color) === "light" ? "0" : "100") + ') !important" src="' + intCookieIcon + '" alt="Cookie Icon">' + IntastellarToolTip + ' ' + text;
-
-banner.appendChild(bannerContent);
-moreSettings.appendChild(moreSettingsContent);
-intaconsents.appendChild(banner);
-intaconsents.appendChild(moreSettings);
-window._intaCookieConstents = intaconsents;
-IntastellarCookieConsent.initialize(intaconsents);
-
-if (document.querySelector(".intastellarCCPAContainer") != null) {
-    document.querySelector(".intastellarCCPAContainer").addEventListener("click", function () {
-        document.querySelector(".intastellarCCPApopup").classList.toggle("--active");
-    })
+if (intaCbResolveTextOverridePresetSlug()) {
+    intaCbFetchTextOverridePresetFromApiIfNeeded().then(function () {
+        intaCbApplyMainBannerDomAndInitialize();
+    });
+} else {
+    intaCbApplyMainBannerDomAndInitialize();
 }
 
 function onWindowLoad(callback) {
@@ -4065,7 +4273,7 @@ function IntaAcceptAll() {
     };
     window.intaCookieConsents = intaConsentsObjectVariable.consents;
     intaConsentsObjectVariable.time = new Date().getTime()
-    var cV = 1;
+    let cV = 1;
     document.cookie =
         int_hideCookieBannerName + "=__inta1." + encodeIntaConsentsObject(JSON.stringify(intaConsentsObjectVariable), randomIntFromInterval(20, 34)) + "; expires=" + cookieLifeTime +
         "; path=/; " +
@@ -4079,8 +4287,8 @@ function IntaAcceptAll() {
         intCookieDomain +
         "";
 
-    var addedNodes = document.getElementsByTagName("script");
-    for (var i = 0; i < addedNodes.length; i++) {
+    let addedNodes = document.getElementsByTagName("script");
+    for (let i = 0; i < addedNodes.length; i++) {
         addedNodes.type = "";
     }
 
@@ -4154,7 +4362,7 @@ function IntaSaveNeccessary() {
     };
     window.intaCookieConsents = intaConsentsObjectVariable.consents;
     intaConsentsObjectVariable.time = new Date().getTime()
-    var cV = 1;
+    let cV = 1;
     document.cookie =
         int_hideCookieBannerName + "=__inta1." + encodeIntaConsentsObject(JSON.stringify(intaConsentsObjectVariable), randomIntFromInterval(20, 34)) + "; expires=" + cookieLifeTime +
         "; path=/; " +
@@ -4340,7 +4548,7 @@ onWindowLoad(function () {
 
     // TCF API locator frame (required for cross-frame communication)
     if (!window.frames['__tcfapiLocator']) {
-        var tcfApiLocator = document.createElement('iframe');
+        let tcfApiLocator = document.createElement('iframe');
         tcfApiLocator.style.display = 'none';
         tcfApiLocator.name = '__tcfapiLocator';
         document.body.appendChild(tcfApiLocator);
@@ -4503,7 +4711,7 @@ onWindowLoad(function () {
         if (button__acceptAll != null || button__acceptAll != undefined) {
             button__acceptAll.addEventListener("click", function () {
 
-                var cV = 0;
+                let cV = 0;
                 intaConsentsObjectVariable.consents = {
                     staticsticCookies: "checked",
                     functionalCookies: "checked",
@@ -4594,7 +4802,7 @@ onWindowLoad(function () {
         if (button__acceptAll != null || button__acceptAll != undefined) {
             button__acceptAll.addEventListener("click", function () {
 
-                var cV = 1;
+                let cV = 1;
                 intaConsentsObjectVariable.consents = {
                     staticsticCookies: "checked",
                     functionalCookies: "checked",
@@ -4623,8 +4831,8 @@ onWindowLoad(function () {
                     "; path=/; " +
                     intCookieDomain +
                     "";
-                var addedNodes = document.getElementsByTagName("script");
-                for (var i = 0; i < addedNodes.length; i++) {
+                let addedNodes = document.getElementsByTagName("script");
+                for (let i = 0; i < addedNodes.length; i++) {
                     addedNodes.type = "";
                 }
                 document.querySelector("html").classList.toggle("noScroll");
@@ -4700,7 +4908,7 @@ onWindowLoad(function () {
                 intaCookieConsents.functionalCookies = false;
 
                 intaConsentsObjectVariable.time = new Date().getTime()
-                var cV = 1;
+                let cV = 1;
                 intaConsentsObjectVariable.time_to_decision = new Date().getTime() - window._intaBannerShownAt;
                 document.cookie =
                     int_hideCookieBannerName + "=__inta1." + encodeIntaConsentsObject(JSON.stringify(intaConsentsObjectVariable), randomIntFromInterval(20, 34)) + "; expires=" + cookieLifeTime +
@@ -4900,8 +5108,8 @@ onWindowLoad(function () {
 
 /* --- Helper function to get Meta tags --- */
 function getMeta(name) {
-    var mtag = document.getElementsByTagName("meta");
-    for (var i = 0; i < mtag.length; i++) {
+    let mtag = document.getElementsByTagName("meta");
+    for (let i = 0; i < mtag.length; i++) {
         if (mtag[i].getAttribute('name') === name) {
             return mtag[i].getAttribute("content")
         }
@@ -4910,7 +5118,7 @@ function getMeta(name) {
 }
 
 function invertColor(color) {
-    var r, g, b, hsp;
+    let r, g, b, hsp;
 
     // Check the format of the color, HEX or RGB?
     if (color.match(/^rgb/)) {
@@ -4948,9 +5156,9 @@ function invertColor(color) {
 }
 
 function listCookies() {
-    var theCookies = document.cookie.split(";");
-    var aString = "";
-    for (var i = 1; i <= theCookies.length; i++) {
+    let theCookies = document.cookie.split(";");
+    let aString = "";
+    for (let i = 1; i <= theCookies.length; i++) {
         aString += i + " " + theCookies[i - 1] + "\n";
     }
     return aString;
@@ -4958,7 +5166,7 @@ function listCookies() {
 
 function allStorage() {
 
-    var values = [],
+    let values = [],
         keys = Object.keys(localStorage),
         i = keys.length;
 
@@ -5768,9 +5976,9 @@ function isCCPAURL(str) {
 /* Helper function to get list of cookies */
 
 function getCookies() {
-    var cookies = document.cookie.split(';');
-    var ret = '';
-    for (var i = 1; i <= cookies.length; i++) {
+    let cookies = document.cookie.split(';');
+    let ret = '';
+    for (let i = 1; i <= cookies.length; i++) {
         ret += i + ' - ' + cookies[i - 1] + "<br>";
     }
     return ret;
@@ -5828,14 +6036,14 @@ function hidePrivacy() {
 }
 
 function checkIfIncluded(file) {
-    var links = document.getElementsByTagName("link");
-    for (var i = 0; i < links.length; i++) {
+    let links = document.getElementsByTagName("link");
+    for (let i = 0; i < links.length; i++) {
         if (links[i].href.substr(-file.length) == file)
             return true;
     }
 
-    var scripts = document.getElementsByTagName("script");
-    for (var i = 0; i < scripts.length; i++) {
+    let scripts = document.getElementsByTagName("script");
+    for (let i = 0; i < scripts.length; i++) {
         if (scripts[i].src.substr(-file.length) == file)
             return true;
     }
@@ -5869,17 +6077,17 @@ function generatePolicyUrl(policy_link_text) {
     return url;
 }
 function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSettingsText) {
-    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
-    var necessaryOnlyText = intaGetNecessaryButtonText(necessaryCookiesText);
-    var settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
+    let acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    let necessaryOnlyText = intaGetNecessaryButtonText(necessaryCookiesText);
+    let settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
     return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button>'
         + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery" onclick="javascript:IntaSaveNeccessary();">' + necessaryOnlyText + '</button>'
         + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings" onclick="javascript:IntaSaveSettings();">' + settingsText + '</button>';
 }
 
 function generateCookieSettingsButton(settingsText, allCookiesText) {
-    var saveSettingsText = intaGetTextOverride("saveSettingsButton", settingsText);
-    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    let saveSettingsText = intaGetTextOverride("saveSettingsButton", settingsText);
+    let acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
     return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save" onclick="javascript:IntaSaveSettings();">' + saveSettingsText + '</button>'
         + '<button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button></section>'
         ;

--- a/dev/cb.dev.js
+++ b/dev/cb.dev.js
@@ -1742,7 +1742,7 @@ if (intastellarCookieLanguage != null) {
     ${(window.INTA.settings.design == "banner" || window.INTA.settings.design == "bannerV2" && window.INTA.settings.logo && window.INTA.settings.logo != "") ? `
        <img class="intSettingsCompanyLogo" src="${window.INTA.settings.logo}" alt="Intastellar Solutions, International">`
                 : ""}
-        ${generateCookieSettingsButton(intastellarSupportedLanguages.english.saveSettings, 'Accept')}
+        ${generateCookieSettingsButton(window.INTA.settings.textOverrides.necessaryButton, 'Accept')}
         <button class="intLearnMoreBtn" onclick="learnMore(this)" >${intastellarShowHideDetailsText}</button>
         <button class="openVendorList" onclick="openVendorList()">Vendor list</button>
         ${(window.INTA.settings.design == "bannerV2" && window.innerWidth > 768 ? generatePoweredBy() : "")}

--- a/dev/cb.js
+++ b/dev/cb.js
@@ -158,6 +158,27 @@ function darkLightCheck(color) {
 
 let message = "";
 let cookieBtn = "";
+function intaGetTextOverrides() {
+    var settings = window.INTA && window.INTA.settings;
+    if (settings && typeof settings.textOverrides === "object" && settings.textOverrides !== null) {
+        return settings.textOverrides;
+    }
+    return {};
+}
+
+function intaGetRawTextOverride(key) {
+    var overrides = intaGetTextOverrides();
+    var value = overrides[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+        return value;
+    }
+    return null;
+}
+
+function intaGetTextOverride(key, fallbackText) {
+    var override = intaGetRawTextOverride(key);
+    return override !== null ? override : fallbackText;
+}
 /* const poweredBy = `<a class="inta-poweredBy" href='https://www.intastellarsolutions.com?utm_source=${encodeURI(window.location.href)}&utm_content=powered_by&utm_medium=referral&utm_campaign=Consents+Block&utm_term=gdpr_banner_logo' target='_blank' rel='noopener' style="align-items: center; text-decoration: none;font-size: 11.5px; color: #000 !important; display: flex; justify-content: center;">powered by <img width="109px" height="20px" style="width: 109px !important; height: 20px !important;margin-left: 10px;" src="https://www.intastellarsolutions.com/assets/intastellar_solutions.svg" alt="Intastellar Solutions, International"></a>`; */
 const banner = document.createElement("inta-consents-settings-btn");
 const bannerContent = document.createElement("button");
@@ -3351,6 +3372,7 @@ if (ccpa) {
 } */
 
 cookieSettingsContent.setAttribute("class", "intastellarCookie-settings__content");
+message = intaGetTextOverride("bannerMessageHtml", message);
 
 let intCookieIconSmallClass = cookieLogo == intCookieIcon ? " intastellarIcon" : "";
 let CompanyLogoName = cookieLogo == intCookieIcon ? "Cookie Icon" : `${document.domain} logo`;
@@ -3799,6 +3821,7 @@ if (intastellarCookieLanguage != null && intastellarCookieLanguage === "en" || i
     settingsSaveLang.necessaryCookiesText = "Afvis";
     settingsSaveLang.saveSettingsText = "Gem";
 }
+settingsSaveLang.necessaryCookiesText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
 
 function updateSaveButtonText() {
     const FunctionalCheckbox = document.querySelector("#functional");
@@ -5320,14 +5343,19 @@ function generatePolicyUrl(policy_link_text) {
     return url;
 }
 function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSettingsText) {
-    return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + allCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery" onclick="javascript:IntaSaveNeccessary();">' + necessaryCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings" onclick="javascript:IntaSaveSettings();">' + cookieSettingsText + '</button>';
+    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    var necessaryOnlyText = intaGetTextOverride("necessaryButton", necessaryCookiesText);
+    var settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
+    return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery" onclick="javascript:IntaSaveNeccessary();">' + necessaryOnlyText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings" onclick="javascript:IntaSaveSettings();">' + settingsText + '</button>';
 }
 
 function generateCookieSettingsButton(settingsText, allCookiesText) {
-    return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save" onclick="javascript:IntaSaveSettings();">' + settingsText + '</button>'
-        + '<button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + allCookiesText + '</button></section>'
+    var saveSettingsText = intaGetTextOverride("saveSettingsButton", settingsText);
+    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save" onclick="javascript:IntaSaveSettings();">' + saveSettingsText + '</button>'
+        + '<button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button></section>'
         ;
 }
 /* - - - Helper function for ccpa URL generator */

--- a/dev/cb.js
+++ b/dev/cb.js
@@ -179,6 +179,17 @@ function intaGetTextOverride(key, fallbackText) {
     var override = intaGetRawTextOverride(key);
     return override !== null ? override : fallbackText;
 }
+
+/** Decline / necessary-only label: primary key `necessaryButton`, aliases `declineButton`, `declineAllButton`. */
+function intaGetNecessaryButtonText(fallbackText) {
+    var o = intaGetRawTextOverride("necessaryButton");
+    if (o !== null) return o;
+    o = intaGetRawTextOverride("declineButton");
+    if (o !== null) return o;
+    o = intaGetRawTextOverride("declineAllButton");
+    if (o !== null) return o;
+    return fallbackText;
+}
 /* const poweredBy = `<a class="inta-poweredBy" href='https://www.intastellarsolutions.com?utm_source=${encodeURI(window.location.href)}&utm_content=powered_by&utm_medium=referral&utm_campaign=Consents+Block&utm_term=gdpr_banner_logo' target='_blank' rel='noopener' style="align-items: center; text-decoration: none;font-size: 11.5px; color: #000 !important; display: flex; justify-content: center;">powered by <img width="109px" height="20px" style="width: 109px !important; height: 20px !important;margin-left: 10px;" src="https://www.intastellarsolutions.com/assets/intastellar_solutions.svg" alt="Intastellar Solutions, International"></a>`; */
 const banner = document.createElement("inta-consents-settings-btn");
 const bannerContent = document.createElement("button");
@@ -3821,7 +3832,7 @@ if (intastellarCookieLanguage != null && intastellarCookieLanguage === "en" || i
     settingsSaveLang.necessaryCookiesText = "Afvis";
     settingsSaveLang.saveSettingsText = "Gem";
 }
-settingsSaveLang.necessaryCookiesText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
+settingsSaveLang.necessaryCookiesText = intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText);
 
 function updateSaveButtonText() {
     const FunctionalCheckbox = document.querySelector("#functional");
@@ -3831,8 +3842,8 @@ function updateSaveButtonText() {
 
     const vendorChecks = document.querySelectorAll('.intCookieSetting__checkbox');
     const vendorLegitChecks = document.querySelectorAll('.intCookieSetting__checkbox-legit');
-    const vendorChecksChecked = Array.from(vendorChecks).every(check => check.checked);
-    const vendorLegitChecksChecked = Array.from(vendorLegitChecks).every(check => check.checked);
+    const vendorChecksChecked = vendorChecks.length > 0 && Array.from(vendorChecks).every(function (check) { return check.checked; });
+    const vendorLegitChecksChecked = vendorLegitChecks.length > 0 && Array.from(vendorLegitChecks).every(function (check) { return check.checked; });
 
     if (!saveBtn) return;
     if (
@@ -3841,9 +3852,9 @@ function updateSaveButtonText() {
         (MarketingCheckBox && MarketingCheckBox.checked) ||
         vendorChecksChecked || vendorLegitChecksChecked
     ) {
-        saveBtn.innerText = settingsSaveLang.saveSettingsText;
+        saveBtn.innerText = intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText);
     } else {
-        saveBtn.innerText = settingsSaveLang.necessaryCookiesText;
+        saveBtn.innerText = intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText);
     }
 }
 
@@ -5344,7 +5355,7 @@ function generatePolicyUrl(policy_link_text) {
 }
 function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSettingsText) {
     var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
-    var necessaryOnlyText = intaGetTextOverride("necessaryButton", necessaryCookiesText);
+    var necessaryOnlyText = intaGetNecessaryButtonText(necessaryCookiesText);
     var settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
     return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll" onclick="javascript:IntaAcceptAll();">' + acceptAllText + '</button>'
         + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery" onclick="javascript:IntaSaveNeccessary();">' + necessaryOnlyText + '</button>'

--- a/dev/gdpr.dev.js
+++ b/dev/gdpr.dev.js
@@ -3604,8 +3604,107 @@ analyticsScript.src = "https://www.intastellarsolutions.com/js/analytics.js?v=" 
 
 intaAppendToDocumentHead(analyticsScript);
 
+/** Merge experiment / server text override keys into `window.INTA.settings.textOverrides`. */
+function intaMergeTextOverridesIntoSettings(incomingTO) {
+    if (!incomingTO || typeof incomingTO !== "object" || incomingTO === null || Array.isArray(incomingTO)) {
+        return;
+    }
+    if (!window.INTA || !window.INTA.settings) {
+        return;
+    }
+    var existingTO = window.INTA.settings.textOverrides;
+    var mergedTO = {};
+    if (existingTO && typeof existingTO === "object" && existingTO !== null && !Array.isArray(existingTO)) {
+        for (var bk in existingTO) {
+            if (existingTO.hasOwnProperty(bk)) {
+                mergedTO[bk] = existingTO[bk];
+            }
+        }
+    }
+    for (var ik in incomingTO) {
+        if (incomingTO.hasOwnProperty(ik)) {
+            mergedTO[ik] = incomingTO[ik];
+        }
+    }
+    window.INTA.settings.textOverrides = mergedTO;
+}
+
+/** Coerce preset JSON to a flat textOverrides map (flat body or `{ textOverrides }`, optional JSON string). */
+function intaNormalizeTextOverridePresetBody(data) {
+    if (data == null) {
+        return null;
+    }
+    if (typeof data === "string") {
+        try {
+            data = JSON.parse(data);
+        } catch (e) {
+            return null;
+        }
+    }
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+        return null;
+    }
+    var nested = data.textOverrides;
+    if (nested && typeof nested === "object" && nested !== null && !Array.isArray(nested) && Object.keys(nested).length > 0) {
+        return nested;
+    }
+    var flat = {};
+    for (var key in data) {
+        if (Object.prototype.hasOwnProperty.call(data, key) && key !== "textOverrides") {
+            flat[key] = data[key];
+        }
+    }
+    return Object.keys(flat).length ? flat : null;
+}
+
+/**
+ * Build URL for a preset text bundle. Optional `window.INTA.experiment.textOverridesPresetUrl`
+ * with `{id}` placeholder, or a directory base (trailing slash optional); otherwise CDN default.
+ */
+function intaBuildTextOverridePresetUrl(presetId) {
+    var exp = window.INTA && window.INTA.experiment;
+    var tmpl = exp && exp.textOverridesPresetUrl;
+    if (typeof tmpl === "string" && tmpl.indexOf("{id}") !== -1) {
+        return tmpl.split("{id}").join(encodeURIComponent(presetId));
+    }
+    if (typeof tmpl === "string" && tmpl.replace(/\s/g, "").length) {
+        return tmpl.replace(/\/?$/, "/") + encodeURIComponent(presetId) + ".json";
+    }
+    return "https://downloads.intastellarsolutions.com/cookieconsents/text-overrides/" + encodeURIComponent(presetId) + ".json";
+}
+
+/** Fetch JSON preset from server; body may be a flat textOverrides map or `{ textOverrides: { ... } }`. */
+function intaFetchTextOverridePresetPromise(presetId) {
+    if (!presetId || typeof fetch !== "function") {
+        return Promise.resolve();
+    }
+    var url = intaBuildTextOverridePresetUrl(presetId);
+    return fetch(url, { credentials: "omit", cache: "no-store" })
+        .then(function (res) {
+            if (!res.ok) {
+                throw new Error("HTTP " + res.status);
+            }
+            return res.json();
+        })
+        .then(function (data) {
+            var payload = intaNormalizeTextOverridePresetBody(data);
+            if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+                intaMergeTextOverridesIntoSettings(payload);
+            }
+            try {
+                window.dispatchEvent(new CustomEvent("inta:text-override-preset-loaded", { detail: { presetId: presetId } }));
+            } catch (e) {
+                /* ignore */
+            }
+        })
+        .catch(function (err) {
+            console.warn("[Intastellar] textOverride preset fetch failed:", presetId, err && err.message ? err.message : err);
+        });
+}
+
 // --- A/B experiment: resolve variant and apply overrides from window.INTA.experiment ---
 (function applyIntaExperiment() {
+    window.__intaTextOverridePresetId = null;
     var exp = window.INTA && window.INTA.experiment;
     if (!exp || !exp.id || !exp.variants || !Object.keys(exp.variants).length) return;
     var expKey = 'inta_exp_' + exp.id;
@@ -3646,24 +3745,25 @@ intaAppendToDocumentHead(analyticsScript);
     if (overrides && typeof overrides === 'object' && window.INTA.settings) {
         for (var key in overrides) {
             if (!overrides.hasOwnProperty(key)) continue;
+            if (key === "textOverridePresetId" || key === "textOverridesPresetId") {
+                continue;
+            }
             if (key === 'textOverrides' && overrides[key] && typeof overrides[key] === 'object' && overrides[key] !== null && !Array.isArray(overrides[key])) {
-                var existingTO = window.INTA.settings.textOverrides;
-                var incomingTO = overrides[key];
-                var mergedTO = {};
-                if (existingTO && typeof existingTO === 'object' && existingTO !== null && !Array.isArray(existingTO)) {
-                    for (var bk in existingTO) {
-                        if (existingTO.hasOwnProperty(bk)) mergedTO[bk] = existingTO[bk];
-                    }
-                }
-                for (var ik in incomingTO) {
-                    if (incomingTO.hasOwnProperty(ik)) mergedTO[ik] = incomingTO[ik];
-                }
-                window.INTA.settings.textOverrides = mergedTO;
+                intaMergeTextOverridesIntoSettings(overrides[key]);
             } else {
                 window.INTA.settings[key] = overrides[key];
             }
         }
     }
+    var presetIdToFetch = null;
+    if (overrides && typeof overrides === "object") {
+        if (overrides.textOverridePresetId != null && String(overrides.textOverridePresetId).trim() !== "") {
+            presetIdToFetch = String(overrides.textOverridePresetId).trim();
+        } else if (overrides.textOverridesPresetId != null && String(overrides.textOverridesPresetId).trim() !== "") {
+            presetIdToFetch = String(overrides.textOverridesPresetId).trim();
+        }
+    }
+    window.__intaTextOverridePresetId = presetIdToFetch;
     window.INTA.experimentVariant = variantId;
     if (window.dataLayer) {
         window.dataLayer.push({ event: 'intastellar_experiment_view', experiment_id: exp.id, variant: variantId });
@@ -3686,11 +3786,27 @@ if (intastellarDevMode) {
 intastellarCreateBanner.async = true;
 intastellarCreateBanner.defer = true;
 
-setTimeout(() => {
-    if (window.INTA.settings) {
-        intaAppendToDocumentHead(intastellarCreateBanner);
-    }
-}, 800);
+(function intaScheduleBannerScriptAfterExperimentText() {
+    var presetId = typeof window.__intaTextOverridePresetId === "string" && window.__intaTextOverridePresetId.length
+        ? window.__intaTextOverridePresetId
+        : null;
+    var fetchP = presetId ? intaFetchTextOverridePresetPromise(presetId) : Promise.resolve();
+    var delayMs = 800;
+    var delayP = new Promise(function (resolve) {
+        setTimeout(resolve, delayMs);
+    });
+    Promise.all([fetchP, delayP])
+        .then(function () {
+            if (window.INTA && window.INTA.settings) {
+                intaAppendToDocumentHead(intastellarCreateBanner);
+            }
+        })
+        .catch(function () {
+            if (window.INTA && window.INTA.settings) {
+                intaAppendToDocumentHead(intastellarCreateBanner);
+            }
+        });
+})();
 
 function updateCookiePreferenceOfBlockedIframes(dataType) {
     if (dataType == "intMarketingCookies") {

--- a/dev/gdpr.dev.js
+++ b/dev/gdpr.dev.js
@@ -3645,7 +3645,21 @@ intaAppendToDocumentHead(analyticsScript);
     var overrides = (v && v.settings) || (exp.overrides && exp.overrides[variantId]) || {};
     if (overrides && typeof overrides === 'object' && window.INTA.settings) {
         for (var key in overrides) {
-            if (overrides.hasOwnProperty(key)) {
+            if (!overrides.hasOwnProperty(key)) continue;
+            if (key === 'textOverrides' && overrides[key] && typeof overrides[key] === 'object' && overrides[key] !== null && !Array.isArray(overrides[key])) {
+                var existingTO = window.INTA.settings.textOverrides;
+                var incomingTO = overrides[key];
+                var mergedTO = {};
+                if (existingTO && typeof existingTO === 'object' && existingTO !== null && !Array.isArray(existingTO)) {
+                    for (var bk in existingTO) {
+                        if (existingTO.hasOwnProperty(bk)) mergedTO[bk] = existingTO[bk];
+                    }
+                }
+                for (var ik in incomingTO) {
+                    if (incomingTO.hasOwnProperty(ik)) mergedTO[ik] = incomingTO[ik];
+                }
+                window.INTA.settings.textOverrides = mergedTO;
+            } else {
                 window.INTA.settings[key] = overrides[key];
             }
         }

--- a/dev/styles/floating.js
+++ b/dev/styles/floating.js
@@ -157,6 +157,27 @@ const IntastellarCookieConsent = {
 
 let message = "";
 let cookieBtn = "";
+function intaGetTextOverrides() {
+    var settings = window.INTA && window.INTA.settings;
+    if (settings && typeof settings.textOverrides === "object" && settings.textOverrides !== null) {
+        return settings.textOverrides;
+    }
+    return {};
+}
+
+function intaGetRawTextOverride(key) {
+    var overrides = intaGetTextOverrides();
+    var value = overrides[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+        return value;
+    }
+    return null;
+}
+
+function intaGetTextOverride(key, fallbackText) {
+    var override = intaGetRawTextOverride(key);
+    return override !== null ? override : fallbackText;
+}
 /* const poweredBy = `<a class="inta-poweredBy" href='https://www.intastellarsolutions.com?utm_source=${encodeURI(window.location.href)}&utm_content=powered_by&utm_medium=referral&utm_campaign=Consents+Block&utm_term=gdpr_banner_logo' target='_blank' rel='noopener' style="align-items: center; text-decoration: none;font-size: 11.5px; color: #000 !important; display: flex; justify-content: center;">powered by <img width="109px" height="20px" style="width: 109px !important; height: 20px !important;margin-left: 10px;" src="https://www.intastellarsolutions.com/assets/intastellar_solutions.svg" alt="Intastellar Solutions, International"></a>`; */
 const banner = document.createElement("inta-consents-settings-btn");
 const bannerContent = document.createElement("button");
@@ -2480,6 +2501,7 @@ if (ccpa && isValidCCPALink()) {
 }
 
 cookieSettingsContent.setAttribute("class", "intastellarCookie-settings__content");
+message = intaGetTextOverride("bannerMessageHtml", message);
 
 let intCookieIconSmallClass = cookieLogo == intCookieIcon ? " intastellarIcon" : "";
 let CompanyLogoName = cookieLogo == intCookieIcon ? "Cookie Icon" : `${document.domain} logo`;
@@ -2709,6 +2731,7 @@ onWindowLoad(function () {
             settingsSaveLang.necessaryCookiesText = "Afvis";
             settingsSaveLang.saveSettingsText = "Gem";
         }
+        settingsSaveLang.necessaryCookiesText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
 
         FunctionalCheckbox?.addEventListener("change", () => {
             document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === false
@@ -4412,14 +4435,19 @@ function generatePolicyUrl(policy_link_text) {
     return url;
 }
 function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSettingsText) {
-    return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll">' + allCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery">' + necessaryCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings">' + cookieSettingsText + '</button>';
+    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    var necessaryOnlyText = intaGetTextOverride("necessaryButton", necessaryCookiesText);
+    var settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
+    return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll">' + acceptAllText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery">' + necessaryOnlyText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings">' + settingsText + '</button>';
 }
 
 function generateCookieSettingsButton(settingsText, allCookiesText) {
-    return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll">' + allCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save">' + settingsText + '</button>'
+    var saveSettingsText = intaGetTextOverride("saveSettingsButton", settingsText);
+    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll">' + acceptAllText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save">' + saveSettingsText + '</button>'
         + '</section>';
 }
 /* - - - Helper function for ccpa URL generator */

--- a/dev/styles/floating.js
+++ b/dev/styles/floating.js
@@ -178,6 +178,17 @@ function intaGetTextOverride(key, fallbackText) {
     var override = intaGetRawTextOverride(key);
     return override !== null ? override : fallbackText;
 }
+
+/** Decline / necessary-only label: primary key `necessaryButton`, aliases `declineButton`, `declineAllButton`. */
+function intaGetNecessaryButtonText(fallbackText) {
+    var o = intaGetRawTextOverride("necessaryButton");
+    if (o !== null) return o;
+    o = intaGetRawTextOverride("declineButton");
+    if (o !== null) return o;
+    o = intaGetRawTextOverride("declineAllButton");
+    if (o !== null) return o;
+    return fallbackText;
+}
 /* const poweredBy = `<a class="inta-poweredBy" href='https://www.intastellarsolutions.com?utm_source=${encodeURI(window.location.href)}&utm_content=powered_by&utm_medium=referral&utm_campaign=Consents+Block&utm_term=gdpr_banner_logo' target='_blank' rel='noopener' style="align-items: center; text-decoration: none;font-size: 11.5px; color: #000 !important; display: flex; justify-content: center;">powered by <img width="109px" height="20px" style="width: 109px !important; height: 20px !important;margin-left: 10px;" src="https://www.intastellarsolutions.com/assets/intastellar_solutions.svg" alt="Intastellar Solutions, International"></a>`; */
 const banner = document.createElement("inta-consents-settings-btn");
 const bannerContent = document.createElement("button");
@@ -2731,27 +2742,27 @@ onWindowLoad(function () {
             settingsSaveLang.necessaryCookiesText = "Afvis";
             settingsSaveLang.saveSettingsText = "Gem";
         }
-        settingsSaveLang.necessaryCookiesText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
+        settingsSaveLang.necessaryCookiesText = intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText);
 
         FunctionalCheckbox?.addEventListener("change", () => {
             document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === false
                 && StaticsCheckBox?.checked === false
                 && MarketingCheckBox?.checked === false
-                ? settingsSaveLang.necessaryCookiesText : settingsSaveLang.saveSettingsText;
+                ? intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText) : intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText);
         })
 
         StaticsCheckBox?.addEventListener("change", () => {
             document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === false
                 && StaticsCheckBox?.checked === false
                 && MarketingCheckBox?.checked === false
-                ? settingsSaveLang.necessaryCookiesText : settingsSaveLang.saveSettingsText;
+                ? intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText) : intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText);
         })
 
         MarketingCheckBox?.addEventListener("change", () => {
             document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === false
                 && StaticsCheckBox?.checked === false
                 && MarketingCheckBox?.checked === false
-                ? settingsSaveLang.necessaryCookiesText : settingsSaveLang.saveSettingsText;
+                ? intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText) : intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText);
         })
 
         document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === true
@@ -2760,7 +2771,7 @@ onWindowLoad(function () {
             || FunctionalCheckbox?.checked === true
             || StaticsCheckBox?.checked === true
             || MarketingCheckBox?.checked === true
-            ? settingsSaveLang.saveSettingsText : settingsSaveLang.necessaryCookiesText
+            ? intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText) : intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText)
 
         const ness = document.getElementsByClassName("intastellarCookieBanner__accpetNecssery");
         const all = document.getElementsByClassName("intastellarCookieSettings--acceptAll");
@@ -4436,7 +4447,7 @@ function generatePolicyUrl(policy_link_text) {
 }
 function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSettingsText) {
     var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
-    var necessaryOnlyText = intaGetTextOverride("necessaryButton", necessaryCookiesText);
+    var necessaryOnlyText = intaGetNecessaryButtonText(necessaryCookiesText);
     var settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
     return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll">' + acceptAllText + '</button>'
         + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery">' + necessaryOnlyText + '</button>'

--- a/floating.js
+++ b/floating.js
@@ -178,6 +178,17 @@ function intaGetTextOverride(key, fallbackText) {
     var override = intaGetRawTextOverride(key);
     return override !== null ? override : fallbackText;
 }
+
+/** Decline / necessary-only label: primary key `necessaryButton`, aliases `declineButton`, `declineAllButton`. */
+function intaGetNecessaryButtonText(fallbackText) {
+    var o = intaGetRawTextOverride("necessaryButton");
+    if (o !== null) return o;
+    o = intaGetRawTextOverride("declineButton");
+    if (o !== null) return o;
+    o = intaGetRawTextOverride("declineAllButton");
+    if (o !== null) return o;
+    return fallbackText;
+}
 /* const poweredBy = `<a class="inta-poweredBy" href='https://www.intastellarsolutions.com?utm_source=${encodeURI(window.location.href)}&utm_content=powered_by&utm_medium=referral&utm_campaign=Consents+Block&utm_term=gdpr_banner_logo' target='_blank' rel='noopener' style="align-items: center; text-decoration: none;font-size: 11.5px; color: #000 !important; display: flex; justify-content: center;">powered by <img width="109px" height="20px" style="width: 109px !important; height: 20px !important;margin-left: 10px;" src="https://www.intastellarsolutions.com/assets/intastellar_solutions.svg" alt="Intastellar Solutions, International"></a>`; */
 const banner = document.createElement("inta-consents-settings-btn");
 const bannerContent = document.createElement("button");
@@ -2733,27 +2744,27 @@ onWindowLoad(function () {
             settingsSaveLang.necessaryCookiesText = "Afvis";
             settingsSaveLang.saveSettingsText = "Gem";
         }
-        settingsSaveLang.necessaryCookiesText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
+        settingsSaveLang.necessaryCookiesText = intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText);
 
         FunctionalCheckbox?.addEventListener("change", () => {
             document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === false
                 && StaticsCheckBox?.checked === false
                 && MarketingCheckBox?.checked === false
-                ? settingsSaveLang.necessaryCookiesText : settingsSaveLang.saveSettingsText;
+                ? intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText) : intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText);
         })
 
         StaticsCheckBox?.addEventListener("change", () => {
             document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === false
                 && StaticsCheckBox?.checked === false
                 && MarketingCheckBox?.checked === false
-                ? settingsSaveLang.necessaryCookiesText : settingsSaveLang.saveSettingsText;
+                ? intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText) : intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText);
         })
 
         MarketingCheckBox?.addEventListener("change", () => {
             document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === false
                 && StaticsCheckBox?.checked === false
                 && MarketingCheckBox?.checked === false
-                ? settingsSaveLang.necessaryCookiesText : settingsSaveLang.saveSettingsText;
+                ? intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText) : intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText);
         })
 
         document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === true
@@ -2762,7 +2773,7 @@ onWindowLoad(function () {
             || FunctionalCheckbox?.checked === true
             || StaticsCheckBox?.checked === true
             || MarketingCheckBox?.checked === true
-            ? settingsSaveLang.saveSettingsText : settingsSaveLang.necessaryCookiesText
+            ? intaGetTextOverride("saveSettingsButton", settingsSaveLang.saveSettingsText) : intaGetNecessaryButtonText(settingsSaveLang.necessaryCookiesText)
 
         const ness = document.getElementsByClassName("intastellarCookieBanner__accpetNecssery");
         const all = document.getElementsByClassName("intastellarCookieSettings--acceptAll");
@@ -4438,7 +4449,7 @@ function generatePolicyUrl(policy_link_text) {
 }
 function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSettingsText) {
     var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
-    var necessaryOnlyText = intaGetTextOverride("necessaryButton", necessaryCookiesText);
+    var necessaryOnlyText = intaGetNecessaryButtonText(necessaryCookiesText);
     var settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
     return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll">' + acceptAllText + '</button>'
         + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery">' + necessaryOnlyText + '</button>'

--- a/floating.js
+++ b/floating.js
@@ -157,6 +157,27 @@ const IntastellarCookieConsent = {
 
 let message = "";
 let cookieBtn = "";
+function intaGetTextOverrides() {
+    var settings = window.INTA && window.INTA.settings;
+    if (settings && typeof settings.textOverrides === "object" && settings.textOverrides !== null) {
+        return settings.textOverrides;
+    }
+    return {};
+}
+
+function intaGetRawTextOverride(key) {
+    var overrides = intaGetTextOverrides();
+    var value = overrides[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+        return value;
+    }
+    return null;
+}
+
+function intaGetTextOverride(key, fallbackText) {
+    var override = intaGetRawTextOverride(key);
+    return override !== null ? override : fallbackText;
+}
 /* const poweredBy = `<a class="inta-poweredBy" href='https://www.intastellarsolutions.com?utm_source=${encodeURI(window.location.href)}&utm_content=powered_by&utm_medium=referral&utm_campaign=Consents+Block&utm_term=gdpr_banner_logo' target='_blank' rel='noopener' style="align-items: center; text-decoration: none;font-size: 11.5px; color: #000 !important; display: flex; justify-content: center;">powered by <img width="109px" height="20px" style="width: 109px !important; height: 20px !important;margin-left: 10px;" src="https://www.intastellarsolutions.com/assets/intastellar_solutions.svg" alt="Intastellar Solutions, International"></a>`; */
 const banner = document.createElement("inta-consents-settings-btn");
 const bannerContent = document.createElement("button");
@@ -2480,6 +2501,7 @@ if (ccpa && isValidCCPALink()) {
 }
 
 cookieSettingsContent.setAttribute("class", "intastellarCookie-settings__content");
+message = intaGetTextOverride("bannerMessageHtml", message);
 
 let intCookieIconSmallClass = cookieLogo == intCookieIcon ? " intastellarIcon" : "";
 let CompanyLogoName = cookieLogo == intCookieIcon ? "Cookie Icon" : `${document.domain} logo`;
@@ -2711,6 +2733,7 @@ onWindowLoad(function () {
             settingsSaveLang.necessaryCookiesText = "Afvis";
             settingsSaveLang.saveSettingsText = "Gem";
         }
+        settingsSaveLang.necessaryCookiesText = intaGetTextOverride("necessaryButton", settingsSaveLang.necessaryCookiesText);
 
         FunctionalCheckbox?.addEventListener("change", () => {
             document.querySelector(".intastellarCookie-settings__btn.intastellarCookieBanner__settings.--save").innerText = FunctionalCheckbox?.checked === false
@@ -4414,14 +4437,19 @@ function generatePolicyUrl(policy_link_text) {
     return url;
 }
 function generateCookieButtons(allCookiesText, necessaryCookiesText, cookieSettingsText) {
-    return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll">' + allCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery">' + necessaryCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings">' + cookieSettingsText + '</button>';
+    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    var necessaryOnlyText = intaGetTextOverride("necessaryButton", necessaryCookiesText);
+    var settingsText = intaGetTextOverride("settingsButton", cookieSettingsText);
+    return '<button class="intastellarCookie-settings__btn --bg intastellarCookieSettings--acceptAll">' + acceptAllText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__accpetNecssery">' + necessaryOnlyText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings">' + settingsText + '</button>';
 }
 
 function generateCookieSettingsButton(settingsText, allCookiesText) {
-    return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll">' + allCookiesText + '</button>'
-        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save">' + settingsText + '</button>'
+    var saveSettingsText = intaGetTextOverride("saveSettingsButton", settingsText);
+    var acceptAllText = intaGetTextOverride("acceptAllButton", allCookiesText);
+    return '<section class="intSettingsButton"><button class="intastellarCookie-settings__btn --noBorderRadius --bg intastellarCookieSettings--acceptAll">' + acceptAllText + '</button>'
+        + '<button class="intastellarCookie-settings__btn intastellarCookieBanner__settings --save">' + saveSettingsText + '</button>'
         + '</section>';
 }
 /* - - - Helper function for ccpa URL generator */

--- a/gdpr-consents.config.js
+++ b/gdpr-consents.config.js
@@ -8,7 +8,7 @@ window.INTA = {
     //         variant_bannerV2: { weight: 50, settings: { design: 'bannerV2' } }
     //     }
     // },
-    experiment: {
+    /* experiment: {
         id: 'floating-banner-test',
         variants: {
             control: { weight: 10 },
@@ -25,7 +25,7 @@ window.INTA = {
                 }
             }
         }
-    },
+    }, */
     policy_link: {
         target: "_blank",
         url: "https://www.intastellarsolutions.com/about/legal/privacy"
@@ -40,7 +40,13 @@ window.INTA = {
         text: false,
         language: "english",
         design: "bannerV2",
-        tcf: true,
+        textOverrides: {
+            bannerMessageHtml: "<p>We use cookies to ensure you get the best experience on our website.</p>",
+            saveSettingsButton: "Save preferences",
+            necessaryButton: "Necessary only",
+            acceptAllButton: "Accept & continue",
+            settingsButton: "Customize",
+        },
         requiredCookies: [
             {
                 cookie: "region",

--- a/gdpr-consents.config.js
+++ b/gdpr-consents.config.js
@@ -8,13 +8,23 @@ window.INTA = {
     //         variant_bannerV2: { weight: 50, settings: { design: 'bannerV2' } }
     //     }
     // },
-    /* experiment: {
+    experiment: {
         id: 'floating-banner-test',
         variants: {
-            control: { weight: 25 },
-            variant_bannerV2: { weight: 50, settings: { design: 'banner', color: '#c4c4c4' } }
+            control: { weight: 10 },
+            variant_bannerV2: { 
+                weight: 90,
+                settings: { 
+                    textOverrides: {
+                        bannerMessageHtml: "<p>We use cookies to ensure you get the best experience on our website.</p>",
+                        saveSettingsButton: "Necessary only",
+                        acceptAllButton: "Accept & continue",
+                        settingsButton: "Customize",
+                    }
+                }
+            }
         }
-    }, */
+    },
     policy_link: {
         target: "_blank",
         url: "https://www.intastellarsolutions.com/about/legal/privacy"
@@ -27,7 +37,7 @@ window.INTA = {
         rootDomain: "example.com",
         color: "#197da1ff",
         text: false,
-        language: "portuguese",
+        language: "english",
         design: "bannerV2",
         tcf: true,
         requiredCookies: [

--- a/gdpr-consents.config.js
+++ b/gdpr-consents.config.js
@@ -10,18 +10,16 @@ window.INTA = {
     // },
     /* experiment: {
         id: 'floating-banner-test',
+        // Optional: URL template for server-stored text presets (default: downloads…/text-overrides/{id}.json)
+        // textOverridesPresetUrl: 'https://downloads.intastellarsolutions.com/cookieconsents/text-overrides/{id}.json',
         variants: {
             control: { weight: 10 },
-            variant_bannerV2: { 
+            variant_bannerV2: {
                 weight: 90,
-                settings: { 
-                    textOverrides: {
-                        bannerMessageHtml: "<p>We use cookies to ensure you get the best experience on our website.</p>",
-                        saveSettingsButton: "Save preferences",
-                        necessaryButton: "Necessary only",
-                        acceptAllButton: "Accept & continue",
-                        settingsButton: "Customize",
-                    }
+                settings: {
+                    // Either inline textOverrides, or a preset id that matches your CDN/DB-backed JSON file:
+                    textOverridePresetId: 'my-preset-slug',
+                    // textOverrides: { bannerMessageHtml: '<p>…</p>', … }
                 }
             }
         }
@@ -40,13 +38,7 @@ window.INTA = {
         text: false,
         language: "english",
         design: "bannerV2",
-        textOverrides: {
-            bannerMessageHtml: "<p>We use cookies to ensure you get the best experience on our website.</p>",
-            saveSettingsButton: "Save preferences",
-            necessaryButton: "Necessary only",
-            acceptAllButton: "Accept & continue",
-            settingsButton: "Customize",
-        },
+        textOverridePresetId: "copy-privacy-forward",
         requiredCookies: [
             {
                 cookie: "region",

--- a/gdpr-consents.config.js
+++ b/gdpr-consents.config.js
@@ -17,7 +17,8 @@ window.INTA = {
                 settings: { 
                     textOverrides: {
                         bannerMessageHtml: "<p>We use cookies to ensure you get the best experience on our website.</p>",
-                        saveSettingsButton: "Necessary only",
+                        saveSettingsButton: "Save preferences",
+                        necessaryButton: "Necessary only",
                         acceptAllButton: "Accept & continue",
                         settingsButton: "Customize",
                     }

--- a/sql/cmp_text_presets_schema_and_seed.sql
+++ b/sql/cmp_text_presets_schema_and_seed.sql
@@ -1,0 +1,129 @@
+-- CMP text-override presets (MariaDB / MySQL 5.7+)
+-- `_preset` = stable identity (slug). `_presets_version` = versioned JSON payload.
+
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `_preset` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `organization_id` BIGINT UNSIGNED NULL DEFAULT NULL,
+  `slug` VARCHAR(191) NOT NULL,
+  `name` VARCHAR(255) NOT NULL DEFAULT '',
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_preset_org_slug` (`organization_id`, `slug`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `_presets_version` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `preset_id` BIGINT UNSIGNED NOT NULL,
+  `version` INT UNSIGNED NOT NULL DEFAULT 1,
+  `status` ENUM('draft', 'published', 'archived') NOT NULL DEFAULT 'draft',
+  `payload` JSON NOT NULL,
+  `published_at` DATETIME(3) NULL DEFAULT NULL,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_preset_version` (`preset_id`, `version`),
+  KEY `idx_preset_status` (`preset_id`, `status`),
+  CONSTRAINT `fk_presets_version_preset`
+    FOREIGN KEY (`preset_id`) REFERENCES `_preset` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
+-- Seed: five presets (one published version each). Slugs = textOverridePresetId.
+-- Set @org to your organisation id, or NULL for global slugs.
+-- ---------------------------------------------------------------------------
+
+SET @org := NULL;
+
+INSERT IGNORE INTO `_preset` (`organization_id`, `slug`, `name`, `created_at`, `updated_at`)
+VALUES
+(@org, 'copy-ultra-short', 'CMP copy — ultra short', CURRENT_TIMESTAMP(3), CURRENT_TIMESTAMP(3)),
+(@org, 'copy-warm-short', 'CMP copy — warm short', CURRENT_TIMESTAMP(3), CURRENT_TIMESTAMP(3)),
+(@org, 'copy-general', 'CMP copy — general', CURRENT_TIMESTAMP(3), CURRENT_TIMESTAMP(3)),
+(@org, 'copy-plain', 'CMP copy — plain', CURRENT_TIMESTAMP(3), CURRENT_TIMESTAMP(3)),
+(@org, 'copy-privacy-forward', 'CMP copy — privacy-forward', CURRENT_TIMESTAMP(3), CURRENT_TIMESTAMP(3));
+
+-- Resolve preset ids by slug (works after first insert; duplicate slug uses existing row)
+SET @p1 := (SELECT `id` FROM `_preset` WHERE (`organization_id` <=> @org) AND `slug` = 'copy-ultra-short' LIMIT 1);
+SET @p2 := (SELECT `id` FROM `_preset` WHERE (`organization_id` <=> @org) AND `slug` = 'copy-warm-short' LIMIT 1);
+SET @p3 := (SELECT `id` FROM `_preset` WHERE (`organization_id` <=> @org) AND `slug` = 'copy-general' LIMIT 1);
+SET @p4 := (SELECT `id` FROM `_preset` WHERE (`organization_id` <=> @org) AND `slug` = 'copy-plain' LIMIT 1);
+SET @p5 := (SELECT `id` FROM `_preset` WHERE (`organization_id` <=> @org) AND `slug` = 'copy-privacy-forward' LIMIT 1);
+
+INSERT INTO `_presets_version` (`preset_id`, `version`, `status`, `payload`, `published_at`, `created_at`)
+VALUES
+(
+  @p1,
+  1,
+  'published',
+  JSON_OBJECT(
+    'bannerMessageHtml', '<p>We use cookies to run the site, measure traffic, and show relevant content. You can accept all, only what is needed, or change choices anytime.</p>',
+    'acceptAllButton', 'Accept all',
+    'necessaryButton', 'Only necessary',
+    'settingsButton', 'Choices',
+    'saveSettingsButton', 'Save choices'
+  ),
+  CURRENT_TIMESTAMP(3),
+  CURRENT_TIMESTAMP(3)
+),
+(
+  @p2,
+  1,
+  'published',
+  JSON_OBJECT(
+    'bannerMessageHtml', '<p>Cookies help this site work and help us improve it. Choose Accept all, Only necessary, or open settings to pick each category.</p>',
+    'acceptAllButton', 'Allow all',
+    'necessaryButton', 'Essential only',
+    'settingsButton', 'Manage cookies',
+    'saveSettingsButton', 'Save my choices'
+  ),
+  CURRENT_TIMESTAMP(3),
+  CURRENT_TIMESTAMP(3)
+),
+(
+  @p3,
+  1,
+  'published',
+  JSON_OBJECT(
+    'bannerMessageHtml', '<p>We use cookies and similar tools for basic functions, statistics, and marketing where allowed. You decide what to allow and can change this later.</p>',
+    'acceptAllButton', 'Allow all cookies',
+    'necessaryButton', 'Reject non-essential',
+    'settingsButton', 'Cookie settings',
+    'saveSettingsButton', 'Save settings'
+  ),
+  CURRENT_TIMESTAMP(3),
+  CURRENT_TIMESTAMP(3)
+),
+(
+  @p4,
+  1,
+  'published',
+  JSON_OBJECT(
+    'bannerMessageHtml', '<p>We save small files on your device to make the site work and to understand how it is used. Pick what you are OK with below.</p>',
+    'acceptAllButton', 'I am OK with all',
+    'necessaryButton', 'Only what the site needs',
+    'settingsButton', 'Let me choose',
+    'saveSettingsButton', 'Save'
+  ),
+  CURRENT_TIMESTAMP(3),
+  CURRENT_TIMESTAMP(3)
+),
+(
+  @p5,
+  1,
+  'published',
+  JSON_OBJECT(
+    'bannerMessageHtml', '<p>We respect your privacy. Cookies help the site function and let us measure and improve the experience. Choose an option or adjust details in settings.</p>',
+    'acceptAllButton', 'Accept',
+    'necessaryButton', 'Decline optional',
+    'settingsButton', 'Details',
+    'saveSettingsButton', 'Confirm choices'
+  ),
+  CURRENT_TIMESTAMP(3),
+  CURRENT_TIMESTAMP(3)
+)
+ON DUPLICATE KEY UPDATE
+  `status` = VALUES(`status`),
+  `payload` = VALUES(`payload`),
+  `published_at` = VALUES(`published_at`);


### PR DESCRIPTION
Implementing the possibility to select a handfull of presets of text for experiments, to run some A/B test.
Later the developer can choose the experiments winner & apply the text to the banner.