### PR TITLE
feat: Update localization for Thai language in cookie consent setting…

### DIFF
--- a/dev/cb.dev.js
+++ b/dev/cb.dev.js
@@ -1105,7 +1105,7 @@ if (intastellarCookieLanguage == "de" || intastellarCookieLanguage == "de-DE" ||
     intastellarCookieLanguageSettings = "إعدادات ملفات تعريف الارتباط";
 } else if (intastellarCookieLanguage == "hi" || intastellarCookieLanguage == "hi" || window.INTA.settings.language == "hi" || window.INTA.settings.language == "hindi") {
     intastellarCookieLanguageSettings = "कुकी सेटिंग्स";
-} else if (intastellarCookieLanguage == "th" || intastellarCookieLanguage == "th" || window.INTA.settings.language == "th" || window.INTA.settings.language == "thai") {
+} else if (intastellarCookieLanguage == "th" || intastellarCookieLanguage == "th-TH" || window.INTA.settings.language == "th" || window.INTA.settings.language == "thai") {
     intastellarCookieLanguageSettings = "การตั้งค่า Cookie";
 } else if (intastellarCookieLanguage == "af" || intastellarCookieLanguage == "af-ZA" || window.INTA.settings.language == "af" || window.INTA.settings.language == "afrikaans") {
     intastellarCookieLanguageSettings = "Koekie Instellings";
@@ -1117,34 +1117,6 @@ if (intastellarCookieLanguage == "de" || intastellarCookieLanguage == "de-DE" ||
     intastellarCookieLanguageSettings = "הגדרות עוגיות";
 } else if (intastellarCookieLanguage == "uk" || intastellarCookieLanguage == "uk-UA" || window.INTA.settings.language == "uk" || window.INTA.settings.language == "ukrainian") {
     intastellarCookieLanguageSettings = "Налаштування куків";
-} else if (intastellarCookieLanguage == "cs" || intastellarCookieLanguage == "cs-CZ" || window.INTA.settings.language == "cs" || window.INTA.settings.language == "czech") {
-    intastellarCookieLanguageSettings = "Nastavení cookies";
-} else if (intastellarCookieLanguage == "hu" || intastellarCookieLanguage == "hu-HU" || window.INTA.settings.language == "hu" || window.INTA.settings.language == "hungarian") {
-    intastellarCookieLanguageSettings = "Cookie beállítások";
-} else if (intastellarCookieLanguage == "el" || intastellarCookieLanguage == "el" || window.INTA.settings.language == "el" || window.INTA.settings.language == "greek") {
-    intastellarCookieLanguageSettings = "Ρυθμίσεις Cookies";
-} else if (intastellarCookieLanguage == "ar" || intastellarCookieLanguage == "ar" || window.INTA.settings.language == "ar" || window.INTA.settings.language == "arabic") {
-    intastellarCookieLanguageSettings = "إعدادات ملفات تعريف الارتباط";
-} else if (intastellarCookieLanguage == "hi" || intastellarCookieLanguage == "hi" || window.INTA.settings.language == "hi" || window.INTA.settings.language == "hindi") {
-    intastellarCookieLanguageSettings = "कुकी सेटिंग्स";
-} else if (intastellarCookieLanguage == "th" || intastellarCookieLanguage == "th" || window.INTA.settings.language == "th" || window.INTA.settings.language == "thai") {
-    intastellarCookieLanguageSettings = "การตั้งค่า Cookie";
-} else if (intastellarCookieLanguage == "af" || intastellarCookieLanguage == "af-ZA" || window.INTA.settings.language == "af" || window.INTA.settings.language == "afrikaans") {
-    intastellarCookieLanguageSettings = "Koekie Instellings";
-} else if (intastellarCookieLanguage == "bg" || intastellarCookieLanguage == "bg-BG" || window.INTA.settings.language == "bg" || window.INTA.settings.language == "bulgarian") {
-    intastellarCookieLanguageSettings = "Настройки на бисквитките";
-} else if (intastellarCookieLanguage == "ro" || intastellarCookieLanguage == "ro-RO" || window.INTA.settings.language == "ro" || window.INTA.settings.language == "romanian") {
-    intastellarCookieLanguageSettings = "Setări cookie";
-} else if (intastellarCookieLanguage == "he" || intastellarCookieLanguage == "he-IL" || window.INTA.settings.language == "he" || window.INTA.settings.language == "hebrew") {
-    intastellarCookieLanguageSettings = "הגדרות עוגיות";
-} else if (intastellarCookieLanguage == "uk" || intastellarCookieLanguage == "uk-UA" || window.INTA.settings.language == "uk" || window.INTA.settings.language == "ukrainian") {
-    intastellarCookieLanguageSettings = "Налаштування куків";
-} else if (intastellarCookieLanguage == "cs" || intastellarCookieLanguage == "cs-CZ" || window.INTA.settings.language == "cs" || window.INTA.settings.language == "czech") {
-    intastellarCookieLanguageSettings = "Nastavení cookies";
-} else if (intastellarCookieLanguage == "hu" || intastellarCookieLanguage == "hu-HU" || window.INTA.settings.language == "hu" || window.INTA.settings.language == "hungarian") {
-    intastellarCookieLanguageSettings = "Cookie beállítások";
-} else if (intastellarCookieLanguage == "el" || intastellarCookieLanguage == "el" || window.INTA.settings.language == "el" || window.INTA.settings.language == "greek") {
-    intastellarCookieLanguageSettings = "Ρυθμίσεις Cookies";
 }
 
 moreSettings.setAttribute("class", "intastellarCookieConstents");
@@ -1425,6 +1397,7 @@ const messages = {
     polish: "Akceptując wszystkie pliki cookie, wspierasz " + document.domain + " w opracowywaniu lepszego rozwiązania dla Ciebie.</p><p>Wybierz, czy chcesz zezwolić tylko na niezbędne pliki cookie, czy zezwolić na wszystkie pliki cookie.",
     chinese: "通过接受所有cookie，您支持" + document.domain + "为您开发更好的解决方案。</p><p>选择是否只允许必要的cookie或允许所有cookie。",
     japanese: "すべてのCookieを受け入れることで、" + document.domain + "がより良いソリューションを開発するのをサポートします。</p><p>必要なCookieのみを許可するか、すべてのCookieを許可するかを選択してください。",
+    thai: "เมื่อคุณยอมรับคุกกี้ทั้งหมด คุณช่วยให้ " + document.domain + " พัฒนาโซลูชันที่ดียิ่งขึ้นสำหรับคุณ</p><p>เลือกว่าต้องการอนุญาตเฉพาะคุกกี้ที่จำเป็นเท่านั้น หรืออนุญาตคุกกี้ทั้งหมด",
     greek: "Αποδεχόμενοι όλα τα cookies, υποστηρίζετε το " + document.domain + " στην ανάπτυξη μιας καλύτερης λύσης για εσάς.</p><p>Επιλέξτε αν θέλετε να επιτρέψετε μόνο τα απαραίτητα cookies ή αν θέλετε να επιτρέψετε όλα τα cookies.",
     afrikaans: "Deur alle koekies te aanvaar, ondersteun u " + document.domain + " in die ontwikkeling van 'n beter oplossing vir u.</p><p>Kies of u slegs die nodige koekies wil toelaat of of u alle koekies wil toelaat.",
     arabic: "من خلال قبول جميع ملفات تعريف الارتباط، فإنك تدعم " + document.domain + " في تطوير حل أفضل لك.</p><p>اختر ما إذا كنت تريد السماح فقط بملفات تعريف الارتباط الضرورية أو ما إذا كنت تريد السماح بجميع ملفات تعريف الارتباط.",
@@ -1695,6 +1668,21 @@ const settingsMessagesLanguages = {
     <p>ウェブサイトの下部 ${(window?.INTA?.settings.arrange == "ltr") ? "左側" : "右側"} 角にある小さなアイコンをクリックすることで、いつでも同意を撤回できます。</p>
     ${generatePolicyUrl('私たちのプライバシーとクッキーポリシー')}
     <button onClick="showPrivacy()" class="intastellarCookie-settings__privacyLink">Intastellar Solutions, International プライバシーポリシー</button>
+    ${(window.INTA.settings.design == "banner" && window.innerWidth > 768 ? generatePoweredBy() : "")
+        }`,
+    thai: `<h3 style="    font-size: 25px;">คุณควบคุมข้อมูลของคุณได้</h3>
+    <p>เราและพันธมิตรที่เชื่อถือได้ใช้เทคโนโลยี เช่น คุกกี้ เพื่อรวบรวมข้อมูลของคุณเพื่อวัตถุประสงค์ต่าง ๆ รวมถึง:</p>
+    <ol>
+        <li>การทำงาน</li>
+        <li>การวิเคราะห์</li>
+        <li>โฆษณา</li>
+    </ol>
+    <p>เมื่อคลิก 'ยอมรับ' แสดงว่าคุณให้ความยินยอมต่อวัตถุประสงค์ทั้งหมดนี้ หรือคุณสามารถเลือกเฉพาะวัตถุประสงค์ที่ต้องการได้โดยทำเครื่องหมายในช่องแล้วคลิก 'บันทึกการตั้งค่า'</p>
+    <p>คุณสามารถถอนความยินยอมได้ตลอดเวลาโดยคลิกไอคอนเล็ก ๆ ที่มุม${(window?.INTA?.settings.arrange == "ltr") ? "ล่างซ้าย" : "ล่างขวา"}ของเว็บไซต์</p>
+    ${generatePolicyUrl('นโยบายความเป็นส่วนตัวและคุกกี้ของเรา')}
+    ${window.INTA.settings.popia ? `<button onclick="showPOPIAModal()" class="intastellarCookie-settings__privacyLink">Your Privacy Rights POPIA</button>` : ""}
+    ${window.INTA.settings.lgpd ? `<button onclick="showLGPDModal()" class="intastellarCookie-settings__privacyLink">Your Privacy Rights LGPD</button>` : "" }
+    <button onClick="showPrivacy()" class="intastellarCookie-settings__privacyLink">Intastellar Solutions, International นโยบายความเป็นส่วนตัว</button>
     ${(window.INTA.settings.design == "banner" && window.innerWidth > 768 ? generatePoweredBy() : "")
         }`,
     korean: `<h3 style="    font-size: 25px;">당신이 통제합니다</h3>
@@ -3651,6 +3639,101 @@ if (intastellarCookieLanguage != null) {
                 </section>
             </article>
     `;
+    } else if (intastellarCookieLanguage == "th" || intastellarCookieLanguage == "th-TH" || window.INTA.settings.language == "th" || window.INTA.settings.language == "thai") {
+        settingsMessage = settingsMessagesLanguages.thai;
+        intastellarShowHideDetailsText = "แสดงรายละเอียด";
+        message =
+            messageWrapStart
+            + messages.thai
+            + messageWrapEnd + generatePolicyUrl('นโยบายความเป็นส่วนตัวและคุกกี้ของเรา');
+        intastellarCookieButtons.innerHTML = `<section class="intCookieSaveSettingsContainer">
+    ${(window.INTA.settings.design == "banner" || window.INTA.settings.design == "bannerV2" && window.INTA.settings.logo && window.INTA.settings.logo != "") ? `
+         <img class="intSettingsCompanyLogo" src="${window.INTA.settings.logo}" alt="Intastellar Solutions, International">`
+                : ""}
+        ${generateCookieSettingsButton(intastellarSupportedLanguages.thai.saveSettings, 'ยอมรับทั้งหมด')}
+        <button class="intLearnMoreBtn" onclick="learnMore(this)" >${intastellarShowHideDetailsText}</button>
+        <button class="openVendorList" onclick="openVendorList()">Vendor list</button>
+        ${(window.INTA.settings.design == "bannerV2" && window.innerWidth > 768 ? generatePoweredBy() : "")}
+    </section>`;
+        cookieBtn = (window.INTA.settings.design == "banner" || window.INTA.settings.design == "bannerV2") + `
+        ${window.INTA.settings.logo && window.INTA.settings.logo != "" ? `<img class="intSettingsCompanyLogo" src="${window.INTA.settings.logo}" alt="Intastellar Solutions, International">` : ""}
+    ` + generateCookieButtons('ยอมรับทั้งหมด', 'ปฏิเสธทั้งหมด', 'การตั้งค่า');
+        moreFooter.innerHTML =
+            `
+        <section class="intastellar_privacyPolicy"></section>
+        <article class="intReadMore">
+            <section class="required">
+                <h3 class="intaExpandCookieList">${intastellarSupportedLanguages.thai.necessary.title} <i class="intastellar__arrow"></i></h3>
+                <p>${intastellarSupportedLanguages.thai.necessary.description}</p>
+                <article class="intaCookieListOverview">
+                ${listAllCookies(inta_requiredCookieList)
+            }
+                </article>
+            </section>
+            <section>
+                <h3 class="intaExpandCookieList">${intastellarSupportedLanguages.thai.functional.title} <i class="intastellar__arrow"></i></h3>
+                <p>${intastellarSupportedLanguages.thai.functional.description}</p>
+                <article class="intaCookieListOverview">
+                    ${listAllCookies(inta_functionalCookieList)
+            }
+                </article>  
+            </section>
+            <section>
+                <h3 class="intaExpandCookieList">${intastellarSupportedLanguages.thai.statisic.title} <i class="intastellar__arrow"></i></h3>
+                <p>${intastellarSupportedLanguages.thai.statisic.description}</p> 
+                <article class="intaCookieListOverview">
+                ${listAllCookies(inta_statisticCookieList)
+            }
+                </article>
+            </section>
+            <section>
+                <h3 class="intaExpandCookieList">${intastellarSupportedLanguages.thai.marketing.title} <i class="intastellar__arrow"></i></h3>
+                <p>${intastellarSupportedLanguages.thai.marketing.description}</p>
+                <article class="intaCookieListOverview">
+                ${listAllCookies(inta_marketingCookieList)
+            }
+                </article>
+            </section>
+        </article>
+        <article class="intCookieSetting__form">
+                <section class="intastellarSettings__control">
+                    <label class="intSettingDisabled checkMarkContainer">
+                        <span class="intSettingsTitle">${intastellarSupportedLanguages.thai.necessary.title}</span>
+                        <span class="intCheckmarkSliderContainer">
+                            <input class="intCookieSetting__checkbox" type="checkbox" disabled checked>
+                            <span class="checkmark round"></span>
+                        </span>
+                    </label>
+                </section>
+                <section class="intastellarSettings__control">
+                    <label class="checkMarkContainer">
+                        <span class="intSettingsTitle">${intastellarSupportedLanguages.thai.functional.title}</span>
+                        <span class="intCheckmarkSliderContainer">
+                            <input onchange="updateSaveButtonText()" class="intCookieSetting__checkbox" id="functional" type="checkbox" ${(getCookie(int_hideCookieBannerName) != "" && getCookie(int_hideCookieBannerName)?.indexOf("__inta") > -1) ? JSON.parse(decodeIntaConsentsObject(getCookie(int_hideCookieBannerName)?.split(".")[2]))?.consents?.functionalCookies : false}>
+                            <span class="checkmark round"></span>
+                        </span>
+                    </label>
+                </section>
+                <section class="intastellarSettings__control">
+                    <label class="checkMarkContainer">
+                        <span class="intSettingsTitle">${intastellarSupportedLanguages.thai.statisic.title}</span>
+                        <span class="intCheckmarkSliderContainer">
+                            <input onchange="updateSaveButtonText()" class="intCookieSetting__checkbox" id="statics" type="checkbox" ${(getCookie(int_hideCookieBannerName) != "" && getCookie(int_hideCookieBannerName)?.indexOf("__inta") > -1) ? JSON.parse(decodeIntaConsentsObject(getCookie(int_hideCookieBannerName)?.split(".")[2]))?.consents?.staticsticCookies : false}>
+                            <span class="checkmark round"></span>
+                        </span>
+                    </label>
+                </section>
+                <section class="intastellarSettings__control">
+                    <label class="checkMarkContainer">
+                        <span class="intSettingsTitle">${intastellarSupportedLanguages.thai.marketing.title}</span>
+                        <span class="intCheckmarkSliderContainer">
+                            <input onchange="updateSaveButtonText()" class="intCookieSetting__checkbox" id="marketing" type="checkbox" ${(getCookie(int_hideCookieBannerName) != "" && getCookie(int_hideCookieBannerName)?.indexOf("__inta") > -1) ? JSON.parse(decodeIntaConsentsObject(getCookie(int_hideCookieBannerName)?.split(".")[2]))?.consents?.advertisementCookies : false}>
+                            <span class="checkmark round"></span>
+                        </span>
+                    </label>
+                </section>
+            </article>
+    `;
     } else if(intastellarCookieLanguage == "pt" || intastellarCookieLanguage == "pt-BR" || window.INTA.settings.language == "pt" || window.INTA.settings.language == "portuguese") {
         // Portuguese
         settingsMessage = settingsMessagesLanguages.portuguese;
@@ -4502,6 +4585,9 @@ if (intastellarCookieLanguage != null && intastellarCookieLanguage === "en" || i
 } else if (intastellarCookieLanguage != null && intastellarCookieLanguage === "ko" || intastellarCookieLanguage === "ko-KR") {
     settingsSaveLang.necessaryCookiesText = "거부";
     settingsSaveLang.saveSettingsText = "저장";
+} else if (intastellarCookieLanguage != null && intastellarCookieLanguage === "th" || intastellarCookieLanguage === "th-TH") {
+    settingsSaveLang.necessaryCookiesText = "ปฏิเสธทั้งหมด";
+    settingsSaveLang.saveSettingsText = "บันทึกการตั้งค่า";
 } else if (intastellarCookieLanguage != null && intastellarCookieLanguage === "et" || intastellarCookieLanguage === "et-EE") {
     settingsSaveLang.necessaryCookiesText = "Keeldu";
     settingsSaveLang.saveSettingsText = "Salvesta seaded";
@@ -6159,6 +6245,8 @@ function learnMore(e) {
             e.innerHTML = "Versteek besonderhede";
         } else if (intastellarCookieLanguage != null && intastellarCookieLanguage === "ko" || intastellarCookieLanguage === "ko-KR") {
             e.innerHTML = "세부정보 숨기기";
+        } else if (intastellarCookieLanguage != null && intastellarCookieLanguage === "th" || intastellarCookieLanguage === "th-TH") {
+            e.innerHTML = "ซ่อนรายละเอียด";
         } else if (intastellarCookieLanguage != null && intastellarCookieLanguage === "fi" || intastellarCookieLanguage === "fi-FI") {
             e.innerHTML = "Piilota yksityiskohdat";
         } else if (intastellarCookieLanguage != null && intastellarCookieLanguage === "no" || intastellarCookieLanguage === "no-NO") {
@@ -6196,6 +6284,8 @@ function learnMore(e) {
             e.innerHTML = "Wys besonderhede";
         } else if (intastellarCookieLanguage != null && intastellarCookieLanguage === "ko" || intastellarCookieLanguage === "ko-KR") {
             e.innerHTML = "세부정보 표시";
+        } else if (intastellarCookieLanguage != null && intastellarCookieLanguage === "th" || intastellarCookieLanguage === "th-TH") {
+            e.innerHTML = "แสดงรายละเอียด";
         }
 
         document.querySelector(".intastellarCookieConstents__contentC").scrollIntoView({

--- a/dev/gdpr.dev.js
+++ b/dev/gdpr.dev.js
@@ -836,7 +836,8 @@ window._intaConsentInitialized = true;
 if (!isGtmMode && !window._gtagDefaultFired && typeof gtag === 'function') {
     // Only set defaults if GTM hasn't already done so
     if (!window.google_tag_manager || !window.google_tag_manager['consent_default_set']) {
-        // Strict opt-in regions (GDPR-style)
+        // Strict opt-in regions (GDPR-style). ISO 3166: 'CA' = Canada, not California.
+        // California is handled separately below via region ['US-CA'] (CCPA / opt-out style).
         gtag('consent', 'default', {
             "ad_storage": 'denied',
             "personalization_storage": 'denied',
@@ -848,11 +849,11 @@ if (!isGtmMode && !window._gtagDefaultFired && typeof gtag === 'function') {
             "security_storage": 'granted',
             "url_passthrough": true,
             "wait_for_update": 500,
-            "region": ['EU', 'UK', 'CH', 'NO', 'IS', 'LI', 'CA', 'BR', 'ZA', 'TR', 'AR', 'IL']
+            "region": ['EU', 'UK', 'CH', 'NO', 'IS', 'LI', 'CA', 'BR', 'ZA', 'TR', 'AR', 'IL', 'TH']
         });
         /* console.log("Intastellar Consents: Applied STRICT defaults (EU/UK/CA/BR/etc.)"); */
 
-        // California opt-out (Do Not Sell)
+        // California only: CCPA-style defaults (region US-CA). Rest of US uses global baseline below.
         gtag('consent', 'default', {
             "ad_storage": 'granted',
             "personalization_storage": 'granted',
@@ -868,20 +869,9 @@ if (!isGtmMode && !window._gtagDefaultFired && typeof gtag === 'function') {
         });
         /* console.log("Intastellar Consents: Applied CALIFORNIA defaults (US-CA)"); */
 
-        // Rest of the world fallback
-        gtag('consent', 'default', {
-            "ad_storage": 'granted',
-            "personalization_storage": 'granted',
-            "analytics_storage": 'granted',
-            "functionality_storage": 'granted',
-            "ads_data_redaction": 'granted',
-            "ad_user_data": 'granted',
-            "ad_personalization": 'granted',
-            "security_storage": 'granted',
-            "url_passthrough": true,
-            "wait_for_update": 500
-        });
-        /* console.log("Intastellar Consents: Applied REST-OF-WORLD defaults"); */
+        // Global baseline: strict (denied) for every region not matched above.
+        // Regional rows above take precedence (strict list + TH, etc., and US-CA opt-out style).
+        // No separate "rest of world granted" row — that would opt non-listed countries in by default.
         gtag('consent', 'default', {
             'ad_storage': 'denied',
             'personalization_storage': 'denied',
@@ -1829,6 +1819,25 @@ let intastellarSupportedLanguages = {
             title: "マーケティング",
             description: "当社は、選択されたパートナーからのWeb技術（Cookieも含む）を使用して、Webサイトやソーシャルメディア上で特にあなた向けにカスタマイズされたコンテンツや広告を表示します。これらのコンテンツは、あなたの使用行動に基づいて選択および表示されます。広告またはマーケティングCookieは、訪問者に関連する広告やマーケティングキャンペーンを提供するために使用されます。これらのCookieは、異なるWebサイトで訪問者を追跡し、個別化された広告を提供するための情報を収集します。"
         }
+    },
+    thai: {
+        saveSettings: "ปฏิเสธทั้งหมด",
+        necessary: {
+            title: "จำเป็น",
+            description: "เทคโนโลยีเว็บและคุกกี้ที่จำเป็นทำให้เว็บไซต์ของเราเข้าถึงและใช้งานได้จากทางเทคนิคสำหรับคุณ ครอบคลุมฟังก์ชันพื้นฐาน เช่น การนำทางบนเว็บไซต์ การแสดงผลที่ถูกต้องในเบราว์เซอร์ของคุณ หรือการขอความยินยอมจากคุณ หากไม่มีเทคโนโลยีและคุกกี้เหล่านี้ เว็บไซต์ของเราจะทำงานไม่ได้ตามปกติ",
+        },
+        functional: {
+            title: "การทำงาน",
+            description: "คุกกี้เชิงฟังก์ชันช่วยให้เราจัดเก็บข้อมูลที่เปลี่ยนแปลงลักษณะหรือพฤติกรรมของเว็บไซต์ เช่น ภาษาหรือภูมิภาคที่คุณต้องการ",
+        },
+        statisic: {
+            title: "สถิติ",
+            description: "เราต้องการพัฒนาประสบการณ์การใช้งานและประสิทธิภาพของเว็บไซต์อย่างต่อเนื่อง จึงใช้เทคโนโลยีวิเคราะห์ (รวมถึงคุกกี้) เพื่อวัดและประเมินแบบไม่ระบุตัวตนว่าฟีเจอร์และเนื้อหาใดของเว็บไซต์ถูกใช้งานอย่างไรและบ่อยเพียงใด เพื่อนำไปปรับปรุงเว็บไซต์ให้เหมาะกับผู้ใช้",
+        },
+        marketing: {
+            title: "การตลาด",
+            description: "เราใช้เทคโนโลยีเว็บ (รวมถึงคุกกี้) จากพันธมิตรที่คัดสรร เพื่อแสดงเนื้อหาและโฆษณาที่ปรับให้เหมาะกับคุณบนเว็บไซต์และโซเชียลมีเดีย โดยเลือกและแสดงผลตามพฤติกรรมการใช้งานของคุณ คุกกี้โฆษณาหรือการตลาดใช้เพื่อแสดงโฆษณาและแคมเปญที่เกี่ยวข้อง ติดตามผู้เยี่ยมชมข้ามเว็บไซต์ และรวบรวมข้อมูลเพื่อนำเสนอโฆษณาเฉพาะบุคคล",
+        },
     },
     greek: {
         saveSettings: "Απόρριψη",

--- a/gdpr-consents.config.js
+++ b/gdpr-consents.config.js
@@ -36,9 +36,8 @@ window.INTA = {
         rootDomain: "example.com",
         color: "#197da1ff",
         text: false,
-        language: "english",
+        language: "thai",
         design: "bannerV2",
-        textOverridePresetId: "copy-privacy-forward",
         requiredCookies: [
             {
                 cookie: "region",


### PR DESCRIPTION
### Changes

- PDPA: e.g. consent defaults / region handling for TH, framework labeling in API or DB, any gtag/consent API tweaks.
- Localization: Thai (th / th-TH / thai setting) for short message, settings body, buttons, category copy via intastellarSupportedLanguages.thai, learnMore, settings save labels.
- Fixes: e.g. removed duplicate intastellarCookieLanguageSettings branches; th-TH on settings title chain.
- Receipt / logging: if this PR includes it—persist banner language (and applied framework for PDPA vs GDPR) on consent save; call out if data transfer is still not implemented.
- Docs / SQL: presets schema/seed, gdpr-consents.config, test page—only if in the diff.